### PR TITLE
`PositiveDouble` prototype: representing a positive and finite numbers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,3 +69,7 @@ kotlin {
     }
   }
 }
+
+tasks.named<Test>("jvmTest") {
+  useJUnitPlatform()
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,1 @@
-rootProject.name = "ArrowMPPTemplate"
+rootProject.name = "Arrow Exact"

--- a/src/commonMain/kotlin/ArrowExactConstraintError.kt
+++ b/src/commonMain/kotlin/ArrowExactConstraintError.kt
@@ -1,0 +1,29 @@
+data class ArrowExactConstraintError(
+  private val constraint: String,
+  private val violatingValue: Any,
+  private val tag: String?,
+  private val requirement: String,
+) : IllegalArgumentException(errorMessage(constraint, violatingValue, tag, requirement))
+
+private fun errorMessage(
+  constraint: String,
+  violatingValue: Any,
+  tag: String?,
+  requirement: String,
+): String = buildString {
+  append("ArrowExact $constraint constraint violated")
+  tag?.let {
+    append(" in \"$it\" call")
+  }
+  append(": $violatingValue must be $requirement.")
+}
+
+
+fun main() {
+  throw ArrowExactConstraintError(
+    constraint = "PositiveDouble",
+    violatingValue = -3.5,
+    tag = "main test",
+    requirement = "must be positive and finite."
+  )
+}

--- a/src/commonMain/kotlin/ArrowExactConstraintViolationError.kt
+++ b/src/commonMain/kotlin/ArrowExactConstraintViolationError.kt
@@ -1,8 +1,8 @@
-data class ArrowExactConstraintError(
-  private val constraint: String,
-  private val violatingValue: Any,
-  private val tag: String?,
-  private val requirement: String,
+open class ArrowExactConstraintViolationError(
+  val constraint: String,
+  val requirement: String,
+  val violatingValue: Any,
+  val tag: String?,
 ) : IllegalArgumentException(errorMessage(constraint, violatingValue, tag, requirement))
 
 private fun errorMessage(
@@ -11,16 +11,16 @@ private fun errorMessage(
   tag: String?,
   requirement: String,
 ): String = buildString {
-  append("ArrowExact $constraint constraint violated")
+  append("[ArrowExact] $constraint constraint violated")
   tag?.let {
-    append(" in \"$it\" call")
+    append(" in \"$it\"")
   }
-  append(": $violatingValue must be $requirement.")
+  append(". The value \"$violatingValue\" doesn't meet the requirement: \"Must be $requirement.\"")
 }
 
 
 fun main() {
-  throw ArrowExactConstraintError(
+  throw ArrowExactConstraintViolationError(
     constraint = "PositiveDouble",
     violatingValue = -3.5,
     tag = "main test",

--- a/src/commonMain/kotlin/ArrowExactConstraintViolationError.kt
+++ b/src/commonMain/kotlin/ArrowExactConstraintViolationError.kt
@@ -1,3 +1,33 @@
+/**
+ * Represents a base error that occurs when a value violates a given constraint.
+ *
+ * This error is thrown when a value does not meet the requirements of a specific constraint, such as the
+ * constraint of being both positive and finite in the case of [PositiveDouble].
+ *
+ * @param constraint A [String] describing the violated constraint, such as "PositiveDouble".
+ * @param requirement A [String] describing the requirement that the violating value failed to meet, such as "a positive and finite number".
+ * @param violatingValue The value that violates the specified constraint.
+ * @param tag An optional [String] that provides additional context or information about the source of the error.
+ *
+ * ### Example:
+ * ```
+ * open class MyCustomConstraintError(
+ *   violatingValue: Double,
+ *   tag: String?,
+ * ) : ArrowExactConstraintViolationError(
+ *   constraint = "MyCustomConstraint",
+ *   requirement = "a custom constraint requirement",
+ *   violatingValue = violatingValue,
+ *   tag = tag
+ * )
+ *
+ * try {
+ *     // code that may throw a MyCustomConstraintError
+ * } catch (e: MyCustomConstraintError) {
+ *     println(e.message) // "Value 'some_value' does not meet the constraint 'MyCustomConstraint', which requires a custom constraint requirement."
+ * }
+ * ```
+ */
 open class ArrowExactConstraintViolationError(
   val constraint: String,
   val requirement: String,

--- a/src/commonMain/kotlin/number/PositiveDouble.kt
+++ b/src/commonMain/kotlin/number/PositiveDouble.kt
@@ -1,0 +1,43 @@
+package number
+
+import arrow.core.None
+import arrow.core.Option
+import arrow.core.Some
+import kotlin.jvm.JvmInline
+
+@JvmInline
+value class PositiveDouble private constructor(val value: Double) : Comparable<PositiveDouble> {
+
+  operator fun plus(other: PositiveDouble): Option<PositiveDouble> =
+    fromDouble(value + other.value)
+
+  operator fun minus(other: PositiveDouble): Option<PositiveDouble> =
+    fromDouble(value - other.value)
+
+  operator fun times(other: PositiveDouble): Option<PositiveDouble> =
+    fromDouble(value * other.value)
+
+  operator fun div(other: PositiveDouble): Option<PositiveDouble> =
+    if (other.value != 0.0) fromDouble(value / other.value) else None
+
+  operator fun rem(other: PositiveDouble): Option<PositiveDouble> =
+    if (other.value != 0.0) fromDouble(value % other.value) else None
+
+  override fun compareTo(other: PositiveDouble): Int = value.compareTo(other.value)
+
+  override fun toString(): String = "Positive($value)"
+
+  companion object {
+    fun fromDouble(value: Double): Option<PositiveDouble> =
+      if (value > 0.0 && value.isFinite()) Some(PositiveDouble(value)) else None
+
+    fun unsafe(value: Double): PositiveDouble = fromDouble(value).fold(
+      ifEmpty = {
+        throw IllegalArgumentException("PositiveDouble#unsafe error: value \"$value\" must be positive and finite.")
+      },
+      ifSome = { it }
+    )
+
+    operator fun invoke(value: Double): Option<PositiveDouble> = fromDouble(value)
+  }
+}

--- a/src/commonMain/kotlin/number/PositiveDouble.kt
+++ b/src/commonMain/kotlin/number/PositiveDouble.kt
@@ -168,7 +168,7 @@ value class PositiveDouble private constructor(val value: Double) : Comparable<P
      * @return [PositiveDouble] if the provided [Double] value is positive and finite, otherwise, throws an exception.
      * @throws [ArrowExactPositiveDoubleConstraintError] when the provided [value] isn't positive and finite.
      */
-    operator fun invoke(value: Double): PositiveDouble = unsafe(value)
+    operator fun invoke(value: Double): PositiveDouble = unsafe(value, tag = "PositiveDouble()")
   }
 
 }

--- a/src/commonMain/kotlin/number/PositiveDouble.kt
+++ b/src/commonMain/kotlin/number/PositiveDouble.kt
@@ -9,7 +9,7 @@ import number.PositiveDouble.Companion.invoke
 import kotlin.jvm.JvmInline
 
 /**
- * Represents a positive and finite [Double] value.
+ * Represents a positive and finite [Double] value in (0, [Double.MAX_VALUE]].
  * **Invariant (property):** The PositiveDouble [value] will always be a finite and positive number.
  * It also overrides the arithmetics operators **addition "+"** [plus], **subtraction "-"** [minus],
  * __multiplication "*"__ [times], **division "/"** [div] and **remainder "%"** [rem] in a type-safe way.
@@ -65,12 +65,29 @@ value class PositiveDouble private constructor(val value: Double) : Comparable<P
 
   /**
    * Subtracts one [PositiveDouble] from another and returns a new [Option] of [PositiveDouble].
+   * @return [Some] if the resulting value is positive and [Double.isFinite], otherwise [None].
+   *
+   * ### Examples:
+   * ```
+   * PositiveDouble(5.0) - PositiveDouble(3.0) // Some(PositiveDouble(2.0))
+   * PositiveDouble(2.0) - PositiveDouble(3.0) // None
+   * ```
    */
   operator fun minus(other: PositiveDouble): Option<PositiveDouble> =
     fromDouble(value - other.value)
 
   /**
    * Multiplies two [PositiveDouble] instances and returns a new [Option] of [PositiveDouble].
+   * @return [Some] if the resulting value is positive and [Double.isFinite], otherwise [None].
+   *
+   * ### Examples:
+   * ```
+   * PositiveDouble(2.0) * PositiveDouble(3.0) // Some(PositiveDouble(6.0))
+   *
+   * // Edge cases
+   * PositiveDouble(Double.MAX_VALUE) * PositiveDouble(0.5) // Some(PositiveDouble(Double.MAX_VALUE / 2))
+   * PositiveDouble(Double.MAX_VALUE) * PositiveDouble(2.0) // None
+   * ```
    */
   operator fun times(other: PositiveDouble): Option<PositiveDouble> =
     fromDouble(value * other.value)
@@ -78,6 +95,15 @@ value class PositiveDouble private constructor(val value: Double) : Comparable<P
   /**
    * Divides one [PositiveDouble] by another and returns a new [Option] of [PositiveDouble].
    * If the divisor is zero, returns [None].
+   * @return [Some] if the resulting value is positive and [Double.isFinite], otherwise [None].
+   *
+   * ### Examples:
+   * ```
+   * PositiveDouble(6.0) / PositiveDouble(2.0) // Some(PositiveDouble(3.0))
+   *
+   * // Edge cases
+   * PositiveDouble(6.0) / PositiveDouble(0.0) // None
+   * ```
    */
   operator fun div(other: PositiveDouble): Option<PositiveDouble> =
     if (other.value != 0.0) fromDouble(value / other.value) else None
@@ -85,6 +111,15 @@ value class PositiveDouble private constructor(val value: Double) : Comparable<P
   /**
    * Computes the remainder of dividing one [PositiveDouble] by another and returns a new [Option] of [PositiveDouble].
    * If the divisor is zero, returns [None].
+   * @return [Some] if the resulting value is positive and [Double.isFinite], otherwise [None].
+   *
+   * ### Examples:
+   * ```
+   * PositiveDouble(7.0) % PositiveDouble(3.0) // Some(PositiveDouble(1.0))
+   *
+   * // Edge cases
+   * PositiveDouble(7.0) % PositiveDouble(0.0) // None
+   * ```
    */
   operator fun rem(other: PositiveDouble): Option<PositiveDouble> =
     if (other.value != 0.0) fromDouble(value % other.value) else None
@@ -95,10 +130,24 @@ value class PositiveDouble private constructor(val value: Double) : Comparable<P
     /**
      * Safely creates a [PositiveDouble] from a [Double] value, returning an [Option] of [PositiveDouble].
      * If the input value is not positive or not finite, returns [None].
+     *
+     * @param value The [Double] value to be converted into a [PositiveDouble].
+     * @return [Some] [PositiveDouble] for positive and finite [Double] values, otherwise [None].
      */
     fun fromDouble(value: Double): Option<PositiveDouble> =
       if (value > 0.0 && value.isFinite()) Some(PositiveDouble(value)) else None
 
+    /**
+     * Creates a [PositiveDouble] from a [Double] value in an unsafe manner.
+     *
+     * ## Dangerous operation
+     * This function should be used with caution as it may throw an exception for invalid input.
+     *
+     * @param value A [Double] value that must be positive and finite.
+     * @param tag An optional [String] used to better localize the failure in case of [ArrowExactPositiveDoubleConstraintError].
+     * @return [PositiveDouble] if the provided [Double] value is positive and finite, otherwise, throws an exception.
+     * @throws [ArrowExactPositiveDoubleConstraintError] when the provided [value] isn't positive and finite.
+     */
     fun unsafe(
       value: Double,
       tag: String = "PositiveDouble#unsafe"
@@ -112,14 +161,56 @@ value class PositiveDouble private constructor(val value: Double) : Comparable<P
       ifSome = { it }
     )
 
+    /**
+     * Creates a [PositiveDouble] from a [Double] value using the [unsafe] method.
+     *
+     * @param value A [Double] value that must be positive and finite.
+     * @return [PositiveDouble] if the provided [Double] value is positive and finite, otherwise, throws an exception.
+     * @throws [ArrowExactPositiveDoubleConstraintError] when the provided [value] isn't positive and finite.
+     */
     operator fun invoke(value: Double): PositiveDouble = unsafe(value)
   }
+
 }
 
-fun PositiveDouble.mapSafe(f: (Double) -> Double): Option<PositiveDouble> =
-  PositiveDouble.fromDouble(f(value))
+/**
+ * Safely applies the provided function [f] to transform the underlying [PositiveDouble.value].
+ *
+ * The transformation function [f] is used to map the current [PositiveDouble.value] to another [Double].
+ * If the result is both finite and positive, a [Some] containing the new [PositiveDouble] is returned.
+ * If the result is not finite or positive, [None] is returned.
+ *
+ * @param f A transformation function that maps the wrapped [PositiveDouble.value] to another [Double].
+ * @return [Some] containing a new [PositiveDouble] if the result of applying [f] is positive and finite, otherwise [None].
+ *
+ * ### Example:
+ * ```
+ * val positive = PositiveDouble(2.0)
+ * val result = positive.mapSafe { it * 3 } // Some(PositiveDouble(6.0))
+ * val negativeResult = positive.mapSafe { -it } // None
+ * ```
+ */
+fun PositiveDouble.mapSafe(f: (Double) -> Double): Option<PositiveDouble> = fromDouble(f(value))
 
 
+/**
+ * Represents an error that occurs when a value violates the constraint of being both positive and finite.
+ *
+ * This error is thrown when a value that does not meet the requirements of a [PositiveDouble] is passed
+ * to an unsafe API, such as [PositiveDouble.unsafe] or [PositiveDouble.invoke].
+ *
+ * @param violatingValue The [Double] value that violates the positive and finite constraint.
+ * @param tag An optional [String] that provides additional context or information about the source of the error.
+ *
+ * ### Example:
+ * ```
+ * try {
+ *     val invalidPositiveDouble = PositiveDouble(-1.0)
+ * } catch (e: ArrowExactPositiveDoubleConstraintError) {
+ *     println(e.message) // "Value '-1.0' does not meet the constraint 'PositiveDouble', which requires a positive and finite number."
+ * }
+ * ```
+ */
 class ArrowExactPositiveDoubleConstraintError(
   violatingValue: Double,
   tag: String?,

--- a/src/commonMain/kotlin/number/PositiveDouble.kt
+++ b/src/commonMain/kotlin/number/PositiveDouble.kt
@@ -4,6 +4,7 @@ import ArrowExactConstraintViolationError
 import arrow.core.None
 import arrow.core.Option
 import arrow.core.Some
+import arrow.core.identity
 import number.PositiveDouble.Companion.fromDouble
 import number.PositiveDouble.Companion.invoke
 import kotlin.jvm.JvmInline
@@ -158,7 +159,7 @@ value class PositiveDouble private constructor(val value: Double) : Comparable<P
           tag = tag,
         )
       },
-      ifSome = { it }
+      ifSome = ::identity
     )
 
     /**

--- a/src/commonMain/kotlin/number/PositiveDouble.kt
+++ b/src/commonMain/kotlin/number/PositiveDouble.kt
@@ -4,31 +4,98 @@ import ArrowExactConstraintViolationError
 import arrow.core.None
 import arrow.core.Option
 import arrow.core.Some
+import number.PositiveDouble.Companion.fromDouble
+import number.PositiveDouble.Companion.invoke
 import kotlin.jvm.JvmInline
 
+/**
+ * Represents a positive and finite [Double] value.
+ * **Invariant (property):** The PositiveDouble [value] will always be a finite and positive number.
+ * It also overrides the arithmetics operators **addition "+"** [plus], **subtraction "-"** [minus],
+ * __multiplication "*"__ [times], **division "/"** [div] and **remainder "%"** [rem] in a type-safe way.
+ *
+ * All operation that return [Option]<PositiveDouble> are type-safe and return [Some] when
+ * the wrapped value is positive and finite and [None] when the invariant is violated.
+ *
+ * ### Usage:
+ * - Use the [fromDouble] function to safely create a [PositiveDouble] instance.
+ * - The [invoke] or [PositiveDouble.unsafe] functions are an unsafe alternative which throws
+ * an [ArrowExactPositiveDoubleConstraintError] for invalid input.
+ *
+ * ### Examples:
+ * ```
+ * // Happy path
+ * val result = PositiveDouble.fromDouble(5.0) // Some(Positive(5.0))
+ *
+ * // Unhappy path
+ * val result = PositiveDouble.fromDouble(-5.0) // None
+ *
+ * // Edge cases
+ * val maxResult = PositiveDouble.fromDouble(Double.MAX_VALUE) // Some(Positive(Double.MAX_VALUE))
+ * val notFiniteResult = PositiveDouble.fromDouble(Double.POSITIVE_INFINITY) // None
+ *
+ * // Addition and subtraction examples
+ * val a = PositiveDouble.fromDouble(2.0) // Some(Positive(2.0))
+ * val b = PositiveDouble.fromDouble(3.0) // Some(Positive(3.0))
+ * val additionResult = a + b // Some(Positive(5.0))
+ * val subtractionResult = a - b // None
+ * ```
+ *
+ * @property value The wrapped positive and finite [Double] value.
+ */
 @JvmInline
 value class PositiveDouble private constructor(val value: Double) : Comparable<PositiveDouble> {
 
+  /**
+   * Adds two [PositiveDouble] instances and returns a new [Option] of PositiveDouble.
+   * @return [Some] if the resulting value is positive and [Double.isFinite], otherwise [None].
+   *
+   * ### Examples:
+   * ```
+   * PositiveDouble(2.0) + PositiveDouble(3.0) // Some(PositiveDouble(5.0))
+   *
+   * // Edge cases
+   * PositiveDouble(Double.MAX_VALUE) + one // Some(PositiveDouble(Double.MAX_VALUE))
+   * PositiveDouble(Double.MAX_VALUE) + PositiveDouble(1_000_000_000.0) // Some(PositiveDouble(Double.MAX_VALUE))
+   * PositiveDouble(Double.MAX_VALUE) + PositiveDouble(Double.MAX_VALUE) // None
+   * ```
+   */
   operator fun plus(other: PositiveDouble): Option<PositiveDouble> =
     fromDouble(value + other.value)
 
+  /**
+   * Subtracts one [PositiveDouble] from another and returns a new [Option] of [PositiveDouble].
+   */
   operator fun minus(other: PositiveDouble): Option<PositiveDouble> =
     fromDouble(value - other.value)
 
+  /**
+   * Multiplies two [PositiveDouble] instances and returns a new [Option] of [PositiveDouble].
+   */
   operator fun times(other: PositiveDouble): Option<PositiveDouble> =
     fromDouble(value * other.value)
 
+  /**
+   * Divides one [PositiveDouble] by another and returns a new [Option] of [PositiveDouble].
+   * If the divisor is zero, returns [None].
+   */
   operator fun div(other: PositiveDouble): Option<PositiveDouble> =
     if (other.value != 0.0) fromDouble(value / other.value) else None
 
+  /**
+   * Computes the remainder of dividing one [PositiveDouble] by another and returns a new [Option] of [PositiveDouble].
+   * If the divisor is zero, returns [None].
+   */
   operator fun rem(other: PositiveDouble): Option<PositiveDouble> =
     if (other.value != 0.0) fromDouble(value % other.value) else None
 
   override fun compareTo(other: PositiveDouble): Int = value.compareTo(other.value)
 
-  override fun toString(): String = "Positive($value)"
-
   companion object {
+    /**
+     * Safely creates a [PositiveDouble] from a [Double] value, returning an [Option] of [PositiveDouble].
+     * If the input value is not positive or not finite, returns [None].
+     */
     fun fromDouble(value: Double): Option<PositiveDouble> =
       if (value > 0.0 && value.isFinite()) Some(PositiveDouble(value)) else None
 

--- a/src/commonTest/kotlin/number/PositiveDoubleTest.kt
+++ b/src/commonTest/kotlin/number/PositiveDoubleTest.kt
@@ -1,0 +1,15 @@
+package number
+
+import ArrowExactConstraintError
+import io.kotest.core.spec.style.FreeSpec
+
+class PositiveDoubleTest : FreeSpec({
+  "throws exception" {
+    throw ArrowExactConstraintError(
+      constraint = "PositiveDouble",
+      violatingValue = -3.5,
+      tag = "main test",
+      requirement = "must be positive and finite."
+    )
+  }
+})

--- a/src/commonTest/kotlin/number/PositiveDoubleTest.kt
+++ b/src/commonTest/kotlin/number/PositiveDoubleTest.kt
@@ -1,15 +1,80 @@
 package number
 
-import ArrowExactConstraintError
+import arrow.core.Some
+import io.kotest.assertions.arrow.core.shouldBeNone
+import io.kotest.assertions.arrow.core.shouldBeSome
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.comparables.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.double
+import io.kotest.property.checkAll
 
 class PositiveDoubleTest : FreeSpec({
-  "throws exception" {
-    throw ArrowExactConstraintError(
-      constraint = "PositiveDouble",
-      violatingValue = -3.5,
-      tag = "main test",
-      requirement = "must be positive and finite."
-    )
+  "[PROPERTY] ∀ PositiveDouble is a positive and finite number" {
+    checkAll(Arb.double()) { double ->
+      val positiveDouble = PositiveDouble.fromDouble(double)
+
+      if (positiveDouble is Some) {
+        val wrappedValue = positiveDouble.value.value
+        wrappedValue shouldBeGreaterThan 0.0
+        wrappedValue.isFinite().shouldBeTrue()
+      }
+    }
   }
+
+  "[UNHAPPY] Unsafe calls throws understandable exception" {
+    val err = shouldThrow<ArrowExactPositiveDoubleConstraintError> {
+      PositiveDouble.unsafe(-3.14)
+    }
+
+    err.violatingValue shouldBe -3.14
+    err.message shouldContain "ArrowExact"
+    err.message shouldContain "PositiveDouble"
+    err.message shouldContain "-3.14"
+    err.message shouldContain "finite"
+    err.message shouldContain "positive"
+  }
+
+  // region Edge cases
+  "[EDGE] Double.MAX_VALUE * Double.MAX_VALUE is None" {
+    val res = positive(Double.MAX_VALUE) * positive(Double.MAX_VALUE)
+    res.shouldBeNone()
+  }
+
+  "[EDGE] Double.MAX_VALUE + 1 = Double.MAX_VALUE" {
+    val res = positive(Double.MAX_VALUE) + positive(1.0)
+
+    res.shouldBeSome(positive(Double.MAX_VALUE))
+  }
+
+  "[EDGE] Double.MAX_VALUE + 100 = Double.MAX_VALUE" {
+    val res = positive(Double.MAX_VALUE) + positive(1_000.0)
+
+    res.shouldBeSome(positive(Double.MAX_VALUE))
+  }
+
+  "[EDGE] Double.MAX_VALUE + Double.MAX_VALUE is None" {
+    val res = positive(Double.MAX_VALUE) + positive(Double.MAX_VALUE)
+
+    res.shouldBeNone()
+  }
+
+  "[EDGE] Double.POSITIVE_INFINITY is None" {
+    val res = PositiveDouble.fromDouble(Double.POSITIVE_INFINITY)
+
+    res.shouldBeNone()
+  }
+
+  "[EDGE] Double.NEGATIVE_INFINITY is None" {
+    val res = PositiveDouble.fromDouble(Double.NEGATIVE_INFINITY)
+
+    res.shouldBeNone()
+  }
+  // endregion
 })
+
+fun positive(double: Double): PositiveDouble = PositiveDouble(double)

--- a/src/commonTest/kotlin/number/PositiveDoubleTest.kt
+++ b/src/commonTest/kotlin/number/PositiveDoubleTest.kt
@@ -7,6 +7,7 @@ import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.comparables.shouldBeGreaterThan
+import io.kotest.matchers.doubles.beWithinPercentageOf
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.property.Arb
@@ -62,13 +63,13 @@ class PositiveDoubleDoubleTest : FreeSpec({
     "[EDGE] Double.MAX_VALUE + 1 = Double.MAX_VALUE" {
       val res = PositiveDouble(Double.MAX_VALUE) + PositiveDouble(1.0)
 
-      res.shouldBeSome(PositiveDouble(Double.MAX_VALUE))
+      res shouldBeSome PositiveDouble(Double.MAX_VALUE)
     }
 
     "[EDGE] Double.MAX_VALUE + some big number = Double.MAX_VALUE" {
       val res = PositiveDouble(Double.MAX_VALUE) + PositiveDouble(1_000_000_000_000_000.0)
 
-      res.shouldBeSome(PositiveDouble(Double.MAX_VALUE))
+      res shouldBeSome PositiveDouble(Double.MAX_VALUE)
     }
 
     "[EDGE] Double.MAX_VALUE + Double.MAX_VALUE is None" {
@@ -78,9 +79,27 @@ class PositiveDoubleDoubleTest : FreeSpec({
     }
   }
 
-  "[EDGE] Double.MAX_VALUE * Double.MAX_VALUE is None" {
-    val res = PositiveDouble(Double.MAX_VALUE) * PositiveDouble(Double.MAX_VALUE)
-    res.shouldBeNone()
+  "Multiplication" - {
+    "[HAPPY] 2 * 3 = 6" {
+      val res = PositiveDouble(2.0) * PositiveDouble(3.0)
+      res shouldBeSome PositiveDouble(6.0)
+    }
+
+    "[EDGE] Double.MAX_VALUE * 0.5 = Double.MAX_VALUE / 2" {
+      val res = PositiveDouble(Double.MAX_VALUE) * PositiveDouble(0.5)
+      res.shouldBeSome()
+      res.value.value shouldBe beWithinPercentageOf(Double.MAX_VALUE / 2, 1.0)
+    }
+
+    "[EDGE] Double.MAX_VALUE * 2 is None" {
+      val res = PositiveDouble(Double.MAX_VALUE) * PositiveDouble(2.0)
+      res.shouldBeNone()
+    }
+
+    "[EDGE] Double.MAX_VALUE * Double.MAX_VALUE is None" {
+      val res = PositiveDouble(Double.MAX_VALUE) * PositiveDouble(Double.MAX_VALUE)
+      res.shouldBeNone()
+    }
   }
 
 })


### PR DESCRIPTION
Based on #4 I've implemented a simple `PositiveDouble` prototype.

**TL;DR;**
- Unsafe creation via `PositiveDouble(5.0)` or `PositiveDouble.unsafe(-2.0)` which throws are exception
- Safe creation using `PositiveDouble.fromDouble(a)` which returns Option
- Overloads for +, -, *, /, %
- `PositiveDouble#mapSafe` extension for safely transforming the wrapped Double value
- `ArrowExactConstraintViolationError` with detailed error message for easier debugging or handling programatically