### PR TITLE
Add spec method to Exact

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Module Arrow Exact
+# Arrow Exact
 
 Arrow Exact allows you to use Kotlin's type system to enforce exactness of data structures.
 
@@ -21,8 +21,8 @@ value class NotBlankString private constructor(val value: String) {
   companion object : Exact<String, NotBlankString>() {
     override fun Raise<ExactError>.spec(raw: String): NotBlankString { 
       ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
-        return NotBlankString(raw)
-      }
+      return NotBlankString(raw)
+    }
   }
 }
 ```
@@ -75,10 +75,10 @@ value class NotBlankString private constructor(val value: String) {
 @JvmInline
 value class NotBlankTrimmedString private constructor(val value: String) { 
   companion object : Exact<String, NotBlankTrimmedString>() { 
-    override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString {
+    override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString { 
       ensure(raw, NotBlankString)
-        return NotBlankTrimmedString(raw.trim())
-      }
+      return NotBlankTrimmedString(raw.trim())
+    }
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -50,6 +50,23 @@ Either.Left(ExactError(message=Cannot be blank.))
 <!--- KNIT example-readme-01.kt -->
 <!--- TEST -->
 
+You can also define `Exact` by using Kotlin delegation.
+<!--- INCLUDE
+import arrow.core.raise.ensure
+import arrow.exact.Exact
+import arrow.exact.ExactError
+-->
+```kotlin
+@JvmInline
+value class NotBlankString private constructor(val value: String) {
+   companion object : Exact<String, NotBlankString> by Exact({
+     ensure(it.isNotBlank()) { ExactError("Cannot be blank.") }
+     NotBlankString(it)
+   })
+}
+```
+<!--- KNIT example-readme-02.kt -->
+
 You can define a second type `NotBlankTrimmedString` that is a `NotBlankString` that is also
 trimmed. Since the `ensure` allows us to compose `Exact` instances, we can easily
 reuse the `NotBlankString` type.
@@ -83,21 +100,4 @@ value class NotBlankTrimmedString private constructor(val value: String) {
 }
 ```
 
-<!--- KNIT example-readme-02.kt -->
-
-You can also define `Exact` by using Kotlin delegation
-<!--- INCLUDE
-import arrow.core.raise.ensure
-import arrow.exact.Exact
-import arrow.exact.ExactError
--->
-```kotlin
-@JvmInline
-value class NotBlankString private constructor(val value: String) {
-   companion object : Exact<String, NotBlankString> by Exact({
-     ensure(it.isNotBlank()) { ExactError("Cannot be blank.") }
-     NotBlankString(it)
-   })
-}
-```
 <!--- KNIT example-readme-03.kt -->

--- a/README.md
+++ b/README.md
@@ -11,17 +11,19 @@ example easily create a `NotBlankString` type that is a `String` that is not bla
 the Arrow's `Raise` DSL to `ensure` the value is not blank.
 
 ```kotlin
+import arrow.core.raise.Raise
 import arrow.core.raise.ensure
 import arrow.exact.Exact
 import arrow.exact.ExactError
-import arrow.exact.exact
 
 @JvmInline
-value class NotBlankString private constructor(val value: String) {
-  companion object : Exact<String, NotBlankString> by exact({
-    ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
-    NotBlankString(raw)
-  })
+value class NotBlankString private constructor(val value: String) { 
+  companion object : Exact<String, NotBlankString>() {
+    override fun Raise<ExactError>.spec(raw: String): NotBlankString { 
+      ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
+        return NotBlankString(raw)
+      }
+  }
 }
 ```
 
@@ -52,26 +54,32 @@ You can define a second type `NotBlankTrimmedString` that is a `NotBlankString` 
 trimmed. Since the `exact` constructor allows us to compose `Exact` instances, we can easily
 reuse the `NotBlankString` type.
 <!--- INCLUDE
+import arrow.core.raise.Raise
 import arrow.core.raise.ensure
 import arrow.exact.Exact
 import arrow.exact.ExactError
-import arrow.exact.exact
+import arrow.exact.ensure
 
-@JvmInline value class NotBlankString private constructor(val value: String) {
-  companion object : Exact<String, NotBlankString> by exact({
-    ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
-    NotBlankString(raw)
-  })
+@JvmInline
+value class NotBlankString private constructor(val value: String) {
+  companion object : Exact<String, NotBlankString>() {
+    override fun Raise<ExactError>.spec(raw: String): NotBlankString {
+      ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
+      return NotBlankString(raw)
+    }
+  }
 }
 -->
 
 ```kotlin
 @JvmInline
-value class NotBlankTrimmedString private constructor(val value: String) {
-  companion object : Exact<String, NotBlankTrimmedString> by exact({
-    val notBlank = ensure(NotBlankString)
-    NotBlankTrimmedString(notBlank.value.trim())
-  })
+value class NotBlankTrimmedString private constructor(val value: String) { 
+  companion object : Exact<String, NotBlankTrimmedString>() { 
+    override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString {
+      ensure(raw, NotBlankString)
+        return NotBlankTrimmedString(raw.trim())
+      }
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ import arrow.exact.ExactError
 
 @JvmInline
 value class NotBlankString private constructor(val value: String) { 
-  companion object : Exact<String, NotBlankString>() {
+  companion object : Exact<String, NotBlankString> {
     override fun Raise<ExactError>.spec(raw: String): NotBlankString { 
       ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
       return NotBlankString(raw)
@@ -51,7 +51,7 @@ Either.Left(ExactError(message=Cannot be blank.))
 <!--- TEST -->
 
 You can define a second type `NotBlankTrimmedString` that is a `NotBlankString` that is also
-trimmed. Since the `exact` constructor allows us to compose `Exact` instances, we can easily
+trimmed. Since the `ensure` allows us to compose `Exact` instances, we can easily
 reuse the `NotBlankString` type.
 <!--- INCLUDE
 import arrow.core.raise.Raise
@@ -62,7 +62,7 @@ import arrow.exact.ensure
 
 @JvmInline
 value class NotBlankString private constructor(val value: String) {
-  companion object : Exact<String, NotBlankString>() {
+  companion object : Exact<String, NotBlankString> {
     override fun Raise<ExactError>.spec(raw: String): NotBlankString {
       ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
       return NotBlankString(raw)
@@ -74,7 +74,7 @@ value class NotBlankString private constructor(val value: String) {
 ```kotlin
 @JvmInline
 value class NotBlankTrimmedString private constructor(val value: String) { 
-  companion object : Exact<String, NotBlankTrimmedString>() { 
+  companion object : Exact<String, NotBlankTrimmedString> { 
     override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString { 
       ensure(raw, NotBlankString)
       return NotBlankTrimmedString(raw.trim())
@@ -84,3 +84,20 @@ value class NotBlankTrimmedString private constructor(val value: String) {
 ```
 
 <!--- KNIT example-readme-02.kt -->
+
+You can also define `Exact` by using Kotlin delegation
+<!--- INCLUDE
+import arrow.core.raise.ensure
+import arrow.exact.Exact
+import arrow.exact.ExactError
+-->
+```kotlin
+@JvmInline
+value class NotBlankString private constructor(val value: String) {
+   companion object : Exact<String, NotBlankString> by Exact({
+     ensure(it.isNotBlank()) { ExactError("Cannot be blank.") }
+     NotBlankString(it)
+   })
+}
+```
+<!--- KNIT example-readme-03.kt -->

--- a/guide/src/commonMain/kotlin/examples/example-exact-01.kt
+++ b/guide/src/commonMain/kotlin/examples/example-exact-01.kt
@@ -8,7 +8,7 @@ import arrow.exact.ExactError
 
 @JvmInline
 value class NotBlankString private constructor(val value: String) {
-  companion object : Exact<String, NotBlankString>() {
+  companion object : Exact<String, NotBlankString> {
     override fun Raise<ExactError>.spec(raw: String): NotBlankString {
       ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
       return NotBlankString(raw)

--- a/guide/src/commonMain/kotlin/examples/example-exact-01.kt
+++ b/guide/src/commonMain/kotlin/examples/example-exact-01.kt
@@ -1,17 +1,19 @@
 // This file was automatically generated from Exact.kt by Knit tool. Do not edit.
 package arrow.exact.knit.example.exampleExact01
 
+import arrow.core.raise.Raise
 import arrow.core.raise.ensure
 import arrow.exact.Exact
 import arrow.exact.ExactError
-import arrow.exact.exact
 
 @JvmInline
 value class NotBlankString private constructor(val value: String) {
-  companion object : Exact<String, NotBlankString> by exact({
-    ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
-    NotBlankString(raw)
-  })
+  companion object : Exact<String, NotBlankString>() {
+    override fun Raise<ExactError>.spec(raw: String): NotBlankString {
+      ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
+      return NotBlankString(raw)
+    }
+  }
 }
 
 fun example() {

--- a/guide/src/commonMain/kotlin/examples/example-exact-02.kt
+++ b/guide/src/commonMain/kotlin/examples/example-exact-02.kt
@@ -1,22 +1,28 @@
 // This file was automatically generated from Exact.kt by Knit tool. Do not edit.
 package arrow.exact.knit.example.exampleExact02
 
+import arrow.core.raise.Raise
 import arrow.core.raise.ensure
 import arrow.exact.Exact
 import arrow.exact.ExactError
-import arrow.exact.exact
+import arrow.exact.ensure
 
-@JvmInline value class NotBlankString private constructor(val value: String) {
-  companion object : Exact<String, NotBlankString> by exact({
-    ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
-    NotBlankString(raw)
-  })
+@JvmInline
+value class NotBlankString private constructor(val value: String) {
+  companion object : Exact<String, NotBlankString>() {
+    override fun Raise<ExactError>.spec(raw: String): NotBlankString {
+      ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
+      return NotBlankString(raw)
+    }
+  }
 }
 
 @JvmInline
 value class NotBlankTrimmedString private constructor(val value: String) {
-  companion object : Exact<String, NotBlankTrimmedString> by exact({
-    val notBlank = ensure(NotBlankString)
-    NotBlankTrimmedString(notBlank.value.trim())
-  })
+  companion object : Exact<String, NotBlankTrimmedString>() {
+    override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString {
+      ensure(raw, NotBlankString)
+      return NotBlankTrimmedString(raw.trim())
+    }
+  }
 }

--- a/guide/src/commonMain/kotlin/examples/example-exact-02.kt
+++ b/guide/src/commonMain/kotlin/examples/example-exact-02.kt
@@ -9,7 +9,7 @@ import arrow.exact.ensure
 
 @JvmInline
 value class NotBlankString private constructor(val value: String) {
-  companion object : Exact<String, NotBlankString>() {
+  companion object : Exact<String, NotBlankString> {
     override fun Raise<ExactError>.spec(raw: String): NotBlankString {
       ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
       return NotBlankString(raw)
@@ -19,7 +19,7 @@ value class NotBlankString private constructor(val value: String) {
 
 @JvmInline
 value class NotBlankTrimmedString private constructor(val value: String) {
-  companion object : Exact<String, NotBlankTrimmedString>() {
+  companion object : Exact<String, NotBlankTrimmedString> {
     override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString {
       ensure(raw, NotBlankString)
       return NotBlankTrimmedString(raw.trim())

--- a/guide/src/commonMain/kotlin/examples/example-exact-02.kt
+++ b/guide/src/commonMain/kotlin/examples/example-exact-02.kt
@@ -1,28 +1,14 @@
 // This file was automatically generated from Exact.kt by Knit tool. Do not edit.
 package arrow.exact.knit.example.exampleExact02
 
-import arrow.core.raise.Raise
 import arrow.core.raise.ensure
 import arrow.exact.Exact
 import arrow.exact.ExactError
-import arrow.exact.ensure
 
 @JvmInline
 value class NotBlankString private constructor(val value: String) {
-  companion object : Exact<String, NotBlankString> {
-    override fun Raise<ExactError>.spec(raw: String): NotBlankString {
-      ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
-      return NotBlankString(raw)
-    }
-  }
-}
-
-@JvmInline
-value class NotBlankTrimmedString private constructor(val value: String) {
-  companion object : Exact<String, NotBlankTrimmedString> {
-    override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString {
-      ensure(raw, NotBlankString)
-      return NotBlankTrimmedString(raw.trim())
-    }
-  }
+  companion object : Exact<String, NotBlankString> by Exact({
+    ensure(it.isNotBlank()) { ExactError("Cannot be blank.") }
+    NotBlankString(it)
+  })
 }

--- a/guide/src/commonMain/kotlin/examples/example-exact-03.kt
+++ b/guide/src/commonMain/kotlin/examples/example-exact-03.kt
@@ -7,8 +7,7 @@ import arrow.exact.Exact
 import arrow.exact.ExactError
 import arrow.exact.ensure
 
-@JvmInline
-value class NotBlankString private constructor(val value: String) {
+class NotBlankString private constructor(val value: String) {
   companion object : Exact<String, NotBlankString> {
     override fun Raise<ExactError>.spec(raw: String): NotBlankString {
       ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }

--- a/guide/src/commonMain/kotlin/examples/example-exact-03.kt
+++ b/guide/src/commonMain/kotlin/examples/example-exact-03.kt
@@ -1,14 +1,28 @@
 // This file was automatically generated from Exact.kt by Knit tool. Do not edit.
 package arrow.exact.knit.example.exampleExact03
 
+import arrow.core.raise.Raise
 import arrow.core.raise.ensure
 import arrow.exact.Exact
 import arrow.exact.ExactError
+import arrow.exact.ensure
 
 @JvmInline
 value class NotBlankString private constructor(val value: String) {
-  companion object : Exact<String, NotBlankString> by Exact({
-    ensure(it.isNotBlank()) { ExactError("Cannot be blank.") }
-    NotBlankString(it)
-  })
+  companion object : Exact<String, NotBlankString> {
+    override fun Raise<ExactError>.spec(raw: String): NotBlankString {
+      ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
+      return NotBlankString(raw)
+    }
+  }
+}
+
+@JvmInline
+value class NotBlankTrimmedString private constructor(val value: String) {
+  companion object : Exact<String, NotBlankTrimmedString> {
+    override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString {
+      ensure(raw, NotBlankString)
+      return NotBlankTrimmedString(raw.trim())
+    }
+  }
 }

--- a/guide/src/commonMain/kotlin/examples/example-exact-03.kt
+++ b/guide/src/commonMain/kotlin/examples/example-exact-03.kt
@@ -1,18 +1,21 @@
 // This file was automatically generated from Exact.kt by Knit tool. Do not edit.
 package arrow.exact.knit.example.exampleExact03
 
+import arrow.core.raise.Raise
 import arrow.core.raise.ensure
 import arrow.exact.Exact
 import arrow.exact.ExactEither
 import arrow.exact.ExactError
-import arrow.exact.exact
-import arrow.exact.exactEither
+import arrow.exact.ensure
 
-@JvmInline value class NotBlankTrimmedString private constructor(val value: String) {
-  companion object : Exact<String, NotBlankTrimmedString> by exact({
-    ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
-    NotBlankTrimmedString(raw.trim())
-  })
+@JvmInline
+value class NotBlankTrimmedString private constructor(val value: String) {
+  companion object : Exact<String, NotBlankTrimmedString>() {
+    override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString {
+      ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
+      return NotBlankTrimmedString(raw.trim())
+    }
+  }
 }
 
 sealed interface UsernameError {
@@ -22,13 +25,15 @@ sealed interface UsernameError {
 
 @JvmInline
 value class Username private constructor(val value: String) {
-  companion object : ExactEither<UsernameError, String, Username> by exactEither({
-    val username =
-      ensure(NotBlankTrimmedString) {
-        UsernameError.Invalid
-      }.value
-    ensure(username.length < 100) { UsernameError.Invalid }
-    ensure(username !in listOf("offensive")) { UsernameError.Offensive(username) }
-    Username(username)
-  })
+  companion object : ExactEither<UsernameError, String, Username>() {
+    override fun Raise<UsernameError>.spec(raw: String): Username {
+      val username =
+        ensure(raw, NotBlankTrimmedString) {
+          UsernameError.Invalid
+        }.value
+      ensure(username.length < 100) { UsernameError.Invalid }
+      ensure(username !in listOf("offensive")) { UsernameError.Offensive(username) }
+      return Username(username)
+    }
+  }
 }

--- a/guide/src/commonMain/kotlin/examples/example-exact-03.kt
+++ b/guide/src/commonMain/kotlin/examples/example-exact-03.kt
@@ -1,39 +1,14 @@
 // This file was automatically generated from Exact.kt by Knit tool. Do not edit.
 package arrow.exact.knit.example.exampleExact03
 
-import arrow.core.raise.Raise
 import arrow.core.raise.ensure
 import arrow.exact.Exact
-import arrow.exact.ExactEither
 import arrow.exact.ExactError
-import arrow.exact.ensure
 
 @JvmInline
-value class NotBlankTrimmedString private constructor(val value: String) {
-  companion object : Exact<String, NotBlankTrimmedString>() {
-    override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString {
-      ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
-      return NotBlankTrimmedString(raw.trim())
-    }
-  }
-}
-
-sealed interface UsernameError {
-  object Invalid : UsernameError
-  data class Offensive(val username: String) : UsernameError
-}
-
-@JvmInline
-value class Username private constructor(val value: String) {
-  companion object : ExactEither<UsernameError, String, Username>() {
-    override fun Raise<UsernameError>.spec(raw: String): Username {
-      val username =
-        ensure(raw, NotBlankTrimmedString) {
-          UsernameError.Invalid
-        }.value
-      ensure(username.length < 100) { UsernameError.Invalid }
-      ensure(username !in listOf("offensive")) { UsernameError.Offensive(username) }
-      return Username(username)
-    }
-  }
+value class NotBlankString private constructor(val value: String) {
+  companion object : Exact<String, NotBlankString> by Exact({
+    ensure(it.isNotBlank()) { ExactError("Cannot be blank.") }
+    NotBlankString(it)
+  })
 }

--- a/guide/src/commonMain/kotlin/examples/example-exact-04.kt
+++ b/guide/src/commonMain/kotlin/examples/example-exact-04.kt
@@ -1,0 +1,39 @@
+// This file was automatically generated from Exact.kt by Knit tool. Do not edit.
+package arrow.exact.knit.example.exampleExact04
+
+import arrow.core.raise.Raise
+import arrow.core.raise.ensure
+import arrow.exact.Exact
+import arrow.exact.ExactEither
+import arrow.exact.ExactError
+import arrow.exact.ensure
+
+@JvmInline
+value class NotBlankTrimmedString private constructor(val value: String) {
+  companion object : Exact<String, NotBlankTrimmedString> {
+    override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString {
+      ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
+      return NotBlankTrimmedString(raw.trim())
+    }
+  }
+}
+
+sealed interface UsernameError {
+  object Invalid : UsernameError
+  data class Offensive(val username: String) : UsernameError
+}
+
+@JvmInline
+value class Username private constructor(val value: String) {
+  companion object : ExactEither<UsernameError, String, Username> {
+    override fun Raise<UsernameError>.spec(raw: String): Username {
+      val username =
+        ensure(raw, NotBlankTrimmedString) {
+          UsernameError.Invalid
+        }.value
+      ensure(username.length < 100) { UsernameError.Invalid }
+      ensure(username !in listOf("offensive")) { UsernameError.Offensive(username) }
+      return Username(username)
+    }
+  }
+}

--- a/guide/src/commonMain/kotlin/examples/example-readme-01.kt
+++ b/guide/src/commonMain/kotlin/examples/example-readme-01.kt
@@ -11,8 +11,8 @@ value class NotBlankString private constructor(val value: String) {
   companion object : Exact<String, NotBlankString>() {
     override fun Raise<ExactError>.spec(raw: String): NotBlankString { 
       ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
-        return NotBlankString(raw)
-      }
+      return NotBlankString(raw)
+    }
   }
 }
 

--- a/guide/src/commonMain/kotlin/examples/example-readme-01.kt
+++ b/guide/src/commonMain/kotlin/examples/example-readme-01.kt
@@ -8,7 +8,7 @@ import arrow.exact.ExactError
 
 @JvmInline
 value class NotBlankString private constructor(val value: String) { 
-  companion object : Exact<String, NotBlankString>() {
+  companion object : Exact<String, NotBlankString> {
     override fun Raise<ExactError>.spec(raw: String): NotBlankString { 
       ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
       return NotBlankString(raw)

--- a/guide/src/commonMain/kotlin/examples/example-readme-01.kt
+++ b/guide/src/commonMain/kotlin/examples/example-readme-01.kt
@@ -1,17 +1,19 @@
 // This file was automatically generated from README.md by Knit tool. Do not edit.
 package arrow.exact.knit.example.exampleReadme01
 
+import arrow.core.raise.Raise
 import arrow.core.raise.ensure
 import arrow.exact.Exact
 import arrow.exact.ExactError
-import arrow.exact.exact
 
 @JvmInline
-value class NotBlankString private constructor(val value: String) {
-  companion object : Exact<String, NotBlankString> by exact({
-    ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
-    NotBlankString(raw)
-  })
+value class NotBlankString private constructor(val value: String) { 
+  companion object : Exact<String, NotBlankString>() {
+    override fun Raise<ExactError>.spec(raw: String): NotBlankString { 
+      ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
+        return NotBlankString(raw)
+      }
+  }
 }
 
 fun example() {

--- a/guide/src/commonMain/kotlin/examples/example-readme-02.kt
+++ b/guide/src/commonMain/kotlin/examples/example-readme-02.kt
@@ -1,22 +1,28 @@
 // This file was automatically generated from README.md by Knit tool. Do not edit.
 package arrow.exact.knit.example.exampleReadme02
 
+import arrow.core.raise.Raise
 import arrow.core.raise.ensure
 import arrow.exact.Exact
 import arrow.exact.ExactError
-import arrow.exact.exact
+import arrow.exact.ensure
 
-@JvmInline value class NotBlankString private constructor(val value: String) {
-  companion object : Exact<String, NotBlankString> by exact({
-    ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
-    NotBlankString(raw)
-  })
+@JvmInline
+value class NotBlankString private constructor(val value: String) {
+  companion object : Exact<String, NotBlankString>() {
+    override fun Raise<ExactError>.spec(raw: String): NotBlankString {
+      ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
+      return NotBlankString(raw)
+    }
+  }
 }
 
 @JvmInline
-value class NotBlankTrimmedString private constructor(val value: String) {
-  companion object : Exact<String, NotBlankTrimmedString> by exact({
-    val notBlank = ensure(NotBlankString)
-    NotBlankTrimmedString(notBlank.value.trim())
-  })
+value class NotBlankTrimmedString private constructor(val value: String) { 
+  companion object : Exact<String, NotBlankTrimmedString>() { 
+    override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString {
+      ensure(raw, NotBlankString)
+        return NotBlankTrimmedString(raw.trim())
+      }
+  }
 }

--- a/guide/src/commonMain/kotlin/examples/example-readme-02.kt
+++ b/guide/src/commonMain/kotlin/examples/example-readme-02.kt
@@ -20,9 +20,9 @@ value class NotBlankString private constructor(val value: String) {
 @JvmInline
 value class NotBlankTrimmedString private constructor(val value: String) { 
   companion object : Exact<String, NotBlankTrimmedString>() { 
-    override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString {
+    override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString { 
       ensure(raw, NotBlankString)
-        return NotBlankTrimmedString(raw.trim())
-      }
+      return NotBlankTrimmedString(raw.trim())
+    }
   }
 }

--- a/guide/src/commonMain/kotlin/examples/example-readme-02.kt
+++ b/guide/src/commonMain/kotlin/examples/example-readme-02.kt
@@ -9,7 +9,7 @@ import arrow.exact.ensure
 
 @JvmInline
 value class NotBlankString private constructor(val value: String) {
-  companion object : Exact<String, NotBlankString>() {
+  companion object : Exact<String, NotBlankString> {
     override fun Raise<ExactError>.spec(raw: String): NotBlankString {
       ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
       return NotBlankString(raw)
@@ -19,7 +19,7 @@ value class NotBlankString private constructor(val value: String) {
 
 @JvmInline
 value class NotBlankTrimmedString private constructor(val value: String) { 
-  companion object : Exact<String, NotBlankTrimmedString>() { 
+  companion object : Exact<String, NotBlankTrimmedString> { 
     override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString { 
       ensure(raw, NotBlankString)
       return NotBlankTrimmedString(raw.trim())

--- a/guide/src/commonMain/kotlin/examples/example-readme-02.kt
+++ b/guide/src/commonMain/kotlin/examples/example-readme-02.kt
@@ -1,28 +1,14 @@
 // This file was automatically generated from README.md by Knit tool. Do not edit.
 package arrow.exact.knit.example.exampleReadme02
 
-import arrow.core.raise.Raise
 import arrow.core.raise.ensure
 import arrow.exact.Exact
 import arrow.exact.ExactError
-import arrow.exact.ensure
 
 @JvmInline
 value class NotBlankString private constructor(val value: String) {
-  companion object : Exact<String, NotBlankString> {
-    override fun Raise<ExactError>.spec(raw: String): NotBlankString {
-      ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
-      return NotBlankString(raw)
-    }
-  }
-}
-
-@JvmInline
-value class NotBlankTrimmedString private constructor(val value: String) { 
-  companion object : Exact<String, NotBlankTrimmedString> { 
-    override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString { 
-      ensure(raw, NotBlankString)
-      return NotBlankTrimmedString(raw.trim())
-    }
-  }
+   companion object : Exact<String, NotBlankString> by Exact({
+     ensure(it.isNotBlank()) { ExactError("Cannot be blank.") }
+     NotBlankString(it)
+   })
 }

--- a/guide/src/commonMain/kotlin/examples/example-readme-03.kt
+++ b/guide/src/commonMain/kotlin/examples/example-readme-03.kt
@@ -1,0 +1,14 @@
+// This file was automatically generated from README.md by Knit tool. Do not edit.
+package arrow.exact.knit.example.exampleReadme03
+
+import arrow.core.raise.ensure
+import arrow.exact.Exact
+import arrow.exact.ExactError
+
+@JvmInline
+value class NotBlankString private constructor(val value: String) {
+   companion object : Exact<String, NotBlankString> by Exact({
+     ensure(it.isNotBlank()) { ExactError("Cannot be blank.") }
+     NotBlankString(it)
+   })
+}

--- a/guide/src/commonMain/kotlin/examples/example-readme-03.kt
+++ b/guide/src/commonMain/kotlin/examples/example-readme-03.kt
@@ -1,14 +1,28 @@
 // This file was automatically generated from README.md by Knit tool. Do not edit.
 package arrow.exact.knit.example.exampleReadme03
 
+import arrow.core.raise.Raise
 import arrow.core.raise.ensure
 import arrow.exact.Exact
 import arrow.exact.ExactError
+import arrow.exact.ensure
 
 @JvmInline
 value class NotBlankString private constructor(val value: String) {
-   companion object : Exact<String, NotBlankString> by Exact({
-     ensure(it.isNotBlank()) { ExactError("Cannot be blank.") }
-     NotBlankString(it)
-   })
+  companion object : Exact<String, NotBlankString> {
+    override fun Raise<ExactError>.spec(raw: String): NotBlankString {
+      ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
+      return NotBlankString(raw)
+    }
+  }
+}
+
+@JvmInline
+value class NotBlankTrimmedString private constructor(val value: String) { 
+  companion object : Exact<String, NotBlankTrimmedString> { 
+    override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString { 
+      ensure(raw, NotBlankString)
+      return NotBlankTrimmedString(raw.trim())
+    }
+  }
 }

--- a/src/commonMain/kotlin/arrow/exact/Exact.kt
+++ b/src/commonMain/kotlin/arrow/exact/Exact.kt
@@ -2,6 +2,7 @@ package arrow.exact
 
 import arrow.core.Either
 import arrow.core.raise.Raise
+import arrow.core.raise.either
 import arrow.core.raise.ensure
 
 /**
@@ -12,17 +13,19 @@ import arrow.core.raise.ensure
  * the Arrow's [Raise] DSL to [ensure] the value is not blank.
  *
  * ```kotlin
+ * import arrow.core.raise.Raise
  * import arrow.core.raise.ensure
  * import arrow.exact.Exact
  * import arrow.exact.ExactError
- * import arrow.exact.exact
  *
  * @JvmInline
  * value class NotBlankString private constructor(val value: String) {
- *   companion object : Exact<String, NotBlankString> by exact({
- *     ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
- *     NotBlankString(raw)
- *   })
+ *   companion object : Exact<String, NotBlankString>() {
+ *     override fun Raise<ExactError>.spec(raw: String): NotBlankString {
+ *       ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
+ *       return NotBlankString(raw)
+ *     }
+ *   }
  * }
  * ```
  *
@@ -51,32 +54,38 @@ import arrow.core.raise.ensure
  * trimmed. Since the `exact` constructor allows us to compose `Exact` instances, we can easily
  * reuse the `NotBlankString` type.
  * <!--- INCLUDE
+ * import arrow.core.raise.Raise
  * import arrow.core.raise.ensure
  * import arrow.exact.Exact
  * import arrow.exact.ExactError
- * import arrow.exact.exact
+ * import arrow.exact.ensure
  *
- * @JvmInline value class NotBlankString private constructor(val value: String) {
- *   companion object : Exact<String, NotBlankString> by exact({
- *     ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
- *     NotBlankString(raw)
- *   })
+ * @JvmInline
+ * value class NotBlankString private constructor(val value: String) {
+ *   companion object : Exact<String, NotBlankString>() {
+ *     override fun Raise<ExactError>.spec(raw: String): NotBlankString {
+ *       ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
+ *       return NotBlankString(raw)
+ *     }
+ *   }
  * }
  * -->
  * ```kotlin
  * @JvmInline
  * value class NotBlankTrimmedString private constructor(val value: String) {
- *   companion object : Exact<String, NotBlankTrimmedString> by exact({
- *     val notBlank = ensure(NotBlankString)
- *     NotBlankTrimmedString(notBlank.value.trim())
- *   })
+ *   companion object : Exact<String, NotBlankTrimmedString>() {
+ *     override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString {
+ *       ensure(raw, NotBlankString)
+ *       return NotBlankTrimmedString(raw.trim())
+ *     }
+ *   }
  * }
  * ```
  * <!--- KNIT example-exact-02.kt -->
  *
  * @see ExactEither if you need to return an [Either] with a custom error type.
  */
-public fun interface Exact<A, out R> : ExactEither<ExactError, A, R>
+public abstract class Exact<A, out B> : ExactEither<ExactError, A, B>()
 
 // TODO: Should we just use `String` ???
 public data class ExactError(val message: String)
@@ -87,18 +96,21 @@ public data class ExactError(val message: String)
  * [ExactError], we can easily combine the two by mapping from [ExactError] to our custom [E] type.
  *
  * <!--- INCLUDE
+ * import arrow.core.raise.Raise
  * import arrow.core.raise.ensure
  * import arrow.exact.Exact
  * import arrow.exact.ExactEither
  * import arrow.exact.ExactError
- * import arrow.exact.exact
- * import arrow.exact.exactEither
+ * import arrow.exact.ensure
  *
- * @JvmInline value class NotBlankTrimmedString private constructor(val value: String) {
- *   companion object : Exact<String, NotBlankTrimmedString> by exact({
- *     ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
- *     NotBlankTrimmedString(raw.trim())
- *   })
+ * @JvmInline
+ * value class NotBlankTrimmedString private constructor(val value: String) {
+ *   companion object : Exact<String, NotBlankTrimmedString>() {
+ *     override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString {
+ *       ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
+ *       return NotBlankTrimmedString(raw.trim())
+ *     }
+ *   }
  * }
  * -->
  * ```kotlin
@@ -109,22 +121,26 @@ public data class ExactError(val message: String)
  *
  * @JvmInline
  * value class Username private constructor(val value: String) {
- *   companion object : ExactEither<UsernameError, String, Username> by exactEither({
- *     val username =
- *       ensure(NotBlankTrimmedString) {
- *         UsernameError.Invalid
- *       }.value
- *     ensure(username.length < 100) { UsernameError.Invalid }
- *     ensure(username !in listOf("offensive")) { UsernameError.Offensive(username) }
- *     Username(username)
- *   })
+ *   companion object : ExactEither<UsernameError, String, Username>() {
+ *     override fun Raise<UsernameError>.spec(raw: String): Username {
+ *       val username =
+ *         ensure(raw, NotBlankTrimmedString) {
+ *           UsernameError.Invalid
+ *         }.value
+ *       ensure(username.length < 100) { UsernameError.Invalid }
+ *       ensure(username !in listOf("offensive")) { UsernameError.Offensive(username) }
+ *       return Username(username)
+ *     }
+ *   }
  * }
  * ```
  * <!--- KNIT example-exact-03.kt -->
  */
-public fun interface ExactEither<out E : Any, A, out R> {
+public abstract class ExactEither<E : Any, A, out R> {
 
-  public fun from(value: A): Either<E, R>
+  protected abstract fun Raise<E>.spec(raw: A): R
+
+  public fun from(value: A): Either<E, R> = either { spec(value) }
 
   public fun fromOrNull(value: A): R? = from(value).getOrNull()
 

--- a/src/commonMain/kotlin/arrow/exact/Exact.kt
+++ b/src/commonMain/kotlin/arrow/exact/Exact.kt
@@ -50,8 +50,25 @@ import arrow.core.raise.ensure
  * <!--- KNIT example-exact-01.kt -->
  * <!--- TEST -->
  *
+ * You can also define [Exact] by using Kotlin delegation.
+ * <!--- INCLUDE
+ * import arrow.core.raise.ensure
+ * import arrow.exact.Exact
+ * import arrow.exact.ExactError
+ * -->
+ * ```kotlin
+ * @JvmInline
+ * value class NotBlankString private constructor(val value: String) {
+ *   companion object : Exact<String, NotBlankString> by Exact({
+ *     ensure(it.isNotBlank()) { ExactError("Cannot be blank.") }
+ *     NotBlankString(it)
+ *   })
+ * }
+ * ```
+ * <!--- KNIT example-exact-02.kt -->
+ *
  * You can define a second type `NotBlankTrimmedString` that is a `NotBlankString` that is also
- * trimmed. Since the `ensure` constructor allows us to compose `Exact` instances, we can easily
+ * trimmed. Since the [ensure] allows us to compose [Exact] instances, we can easily
  * reuse the `NotBlankString` type.
  * <!--- INCLUDE
  * import arrow.core.raise.Raise
@@ -81,28 +98,11 @@ import arrow.core.raise.ensure
  *   }
  * }
  * ```
- * <!--- KNIT example-exact-02.kt -->
- *
- * You can also define [Exact] by using Kotlin delegation
- * <!--- INCLUDE
- * import arrow.core.raise.ensure
- * import arrow.exact.Exact
- * import arrow.exact.ExactError
- * -->
- * ```kotlin
- * @JvmInline
- * value class NotBlankString private constructor(val value: String) {
- *   companion object : Exact<String, NotBlankString> by Exact({
- *     ensure(it.isNotBlank()) { ExactError("Cannot be blank.") }
- *     NotBlankString(it)
- *   })
- * }
- * ```
  * <!--- KNIT example-exact-03.kt -->
  *
  * @see ExactEither if you need to return an [Either] with a custom error type.
  */
-public fun interface Exact<A, out B> : ExactEither<ExactError, A, B>
+public fun interface Exact<A, out R> : ExactEither<ExactError, A, R>
 
 // TODO: Should we just use `String` ???
 public data class ExactError(val message: String)

--- a/src/commonMain/kotlin/arrow/exact/Exact.kt
+++ b/src/commonMain/kotlin/arrow/exact/Exact.kt
@@ -77,8 +77,7 @@ import arrow.core.raise.ensure
  * import arrow.exact.ExactError
  * import arrow.exact.ensure
  *
- * @JvmInline
- * value class NotBlankString private constructor(val value: String) {
+ * class NotBlankString private constructor(val value: String) {
  *   companion object : Exact<String, NotBlankString> {
  *     override fun Raise<ExactError>.spec(raw: String): NotBlankString {
  *       ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }

--- a/src/commonMain/kotlin/arrow/exact/Exact.kt
+++ b/src/commonMain/kotlin/arrow/exact/Exact.kt
@@ -20,7 +20,7 @@ import arrow.core.raise.ensure
  *
  * @JvmInline
  * value class NotBlankString private constructor(val value: String) {
- *   companion object : Exact<String, NotBlankString>() {
+ *   companion object : Exact<String, NotBlankString> {
  *     override fun Raise<ExactError>.spec(raw: String): NotBlankString {
  *       ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
  *       return NotBlankString(raw)
@@ -51,7 +51,7 @@ import arrow.core.raise.ensure
  * <!--- TEST -->
  *
  * You can define a second type `NotBlankTrimmedString` that is a `NotBlankString` that is also
- * trimmed. Since the `exact` constructor allows us to compose `Exact` instances, we can easily
+ * trimmed. Since the `ensure` constructor allows us to compose `Exact` instances, we can easily
  * reuse the `NotBlankString` type.
  * <!--- INCLUDE
  * import arrow.core.raise.Raise
@@ -62,7 +62,7 @@ import arrow.core.raise.ensure
  *
  * @JvmInline
  * value class NotBlankString private constructor(val value: String) {
- *   companion object : Exact<String, NotBlankString>() {
+ *   companion object : Exact<String, NotBlankString> {
  *     override fun Raise<ExactError>.spec(raw: String): NotBlankString {
  *       ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
  *       return NotBlankString(raw)
@@ -73,7 +73,7 @@ import arrow.core.raise.ensure
  * ```kotlin
  * @JvmInline
  * value class NotBlankTrimmedString private constructor(val value: String) {
- *   companion object : Exact<String, NotBlankTrimmedString>() {
+ *   companion object : Exact<String, NotBlankTrimmedString> {
  *     override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString {
  *       ensure(raw, NotBlankString)
  *       return NotBlankTrimmedString(raw.trim())
@@ -83,9 +83,26 @@ import arrow.core.raise.ensure
  * ```
  * <!--- KNIT example-exact-02.kt -->
  *
+ * You can also define [Exact] by using Kotlin delegation
+ * <!--- INCLUDE
+ * import arrow.core.raise.ensure
+ * import arrow.exact.Exact
+ * import arrow.exact.ExactError
+ * -->
+ * ```kotlin
+ * @JvmInline
+ * value class NotBlankString private constructor(val value: String) {
+ *   companion object : Exact<String, NotBlankString> by Exact({
+ *     ensure(it.isNotBlank()) { ExactError("Cannot be blank.") }
+ *     NotBlankString(it)
+ *   })
+ * }
+ * ```
+ * <!--- KNIT example-exact-03.kt -->
+ *
  * @see ExactEither if you need to return an [Either] with a custom error type.
  */
-public abstract class Exact<A, out B> : ExactEither<ExactError, A, B>()
+public fun interface Exact<A, out B> : ExactEither<ExactError, A, B>
 
 // TODO: Should we just use `String` ???
 public data class ExactError(val message: String)
@@ -105,7 +122,7 @@ public data class ExactError(val message: String)
  *
  * @JvmInline
  * value class NotBlankTrimmedString private constructor(val value: String) {
- *   companion object : Exact<String, NotBlankTrimmedString>() {
+ *   companion object : Exact<String, NotBlankTrimmedString> {
  *     override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString {
  *       ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
  *       return NotBlankTrimmedString(raw.trim())
@@ -121,7 +138,7 @@ public data class ExactError(val message: String)
  *
  * @JvmInline
  * value class Username private constructor(val value: String) {
- *   companion object : ExactEither<UsernameError, String, Username>() {
+ *   companion object : ExactEither<UsernameError, String, Username> {
  *     override fun Raise<UsernameError>.spec(raw: String): Username {
  *       val username =
  *         ensure(raw, NotBlankTrimmedString) {
@@ -134,11 +151,11 @@ public data class ExactError(val message: String)
  *   }
  * }
  * ```
- * <!--- KNIT example-exact-03.kt -->
+ * <!--- KNIT example-exact-04.kt -->
  */
-public abstract class ExactEither<E : Any, A, out R> {
+public fun interface ExactEither<E : Any, A, out R> {
 
-  protected abstract fun Raise<E>.spec(raw: A): R
+  public fun Raise<E>.spec(raw: A): R
 
   public fun from(value: A): Either<E, R> = either { spec(value) }
 

--- a/src/commonMain/kotlin/arrow/exact/ExactDsl.kt
+++ b/src/commonMain/kotlin/arrow/exact/ExactDsl.kt
@@ -13,9 +13,9 @@ public inline fun <A, B, Error : Any> Raise<Error>.ensure(raw: A, exact: ExactEi
 }
 
 @RaiseDSL
-public inline fun <A, B, Error> Raise<Error>.ensure(raw: A, exact: Exact<A, B>, error: () -> Error): B {
+public inline fun <A, B, Error> Raise<Error>.ensure(raw: A, exact: Exact<A, B>, error: (ExactError) -> Error): B {
   return when (val result = exact.from(raw)) {
-    is Either.Left -> raise(error())
+    is Either.Left -> raise(error(result.value))
     is Either.Right -> result.value
   }
 }

--- a/src/commonMain/kotlin/arrow/exact/ExactDsl.kt
+++ b/src/commonMain/kotlin/arrow/exact/ExactDsl.kt
@@ -2,33 +2,20 @@ package arrow.exact
 
 import arrow.core.Either
 import arrow.core.raise.Raise
-import arrow.core.raise.either
+import arrow.core.raise.RaiseDSL
 
-@DslMarker public annotation class ExactDsl
-
-@ExactDsl
-public fun <A, R> exact(construct: ExactScope<A, ExactError>.() -> R): Exact<A, R> =
-  Exact { value -> either { construct(ExactScope(value, this)) } }
-
-@ExactDsl
-public fun <E : Any, A, R> exactEither(construct: ExactScope<A, E>.() -> R): ExactEither<E, A, R> =
-  ExactEither { value -> either { construct(ExactScope(value, this)) } }
-
-public class ExactScope<A, E : Any>(public val raw: A, raise: Raise<E>) : Raise<E> by raise {
-
-  @ExactDsl
-  public fun <B> ensure(exact: ExactEither<E, A, B>): B {
-    return when (val result = exact.from(raw)) {
-      is Either.Left -> raise(result.value)
-      is Either.Right -> result.value
-    }
+@RaiseDSL
+public inline fun <A, B, Error : Any> Raise<Error>.ensure(raw: A, exact: ExactEither<Error, A, B>): B {
+  return when (val result = exact.from(raw)) {
+    is Either.Left -> raise(result.value)
+    is Either.Right -> result.value
   }
+}
 
-  @ExactDsl
-  public fun <B> ensure(exact: Exact<A, B>, error: () -> E): B {
-    return when (val result = exact.from(raw)) {
-      is Either.Left -> raise(error())
-      is Either.Right -> result.value
-    }
+@RaiseDSL
+public inline fun <A, B, Error> Raise<Error>.ensure(raw: A, exact: Exact<A, B>, error: () -> Error): B {
+  return when (val result = exact.from(raw)) {
+    is Either.Left -> raise(error())
+    is Either.Right -> result.value
   }
 }


### PR DESCRIPTION
- ~~Changed `Exact` to abstract class instead of interface~~ Add `spec` function in `ExactEither` with context of `Raise` so that clients can both use implementation and implementation by delegation
  - ~~I suggest that developers won't need to implement/extend their companion objects in most scenarios, so that restriction won't be a big problem~~
  - ~~Extending from abstract class~~ Implementing feels more "natural" than delegating using `by` and I think it will be more convenient for clients. But let's keep delegation is a viable alternative
- Removed `ExactScope` in favour of extending `Raise`
  - I suggest that it will be better to limit amount of new abstractions and reuse existing one as much as possible
  - Also removed `ExactDsl`, I will agree with @CLOVIS-AI in https://github.com/arrow-kt/arrow-exact/issues/15, adding a separate dsl marker for methods with same semantics will look confusing for clients of library