### PR TITLE
Add more ensure functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@ the Arrow's `Raise` DSL to `ensure` the value is not blank.
 
 ```kotlin
 import arrow.core.raise.Raise
-import arrow.core.raise.ensure
 import arrow.exact.Exact
 import arrow.exact.ExactError
+import arrow.exact.ensure
 
 @JvmInline
 value class NotBlankString private constructor(val value: String) { 
   companion object : Exact<String, NotBlankString> {
     override fun Raise<ExactError>.spec(raw: String): NotBlankString { 
-      ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
+      ensure(raw.isNotBlank())
       return NotBlankString(raw)
     }
   }
@@ -44,7 +44,7 @@ The output of the above program is:
 
 ```text
 Either.Right(NotBlankString(value=Hello))
-Either.Left(ExactError(message=Cannot be blank.))
+Either.Left(ExactError(message=Failed condition.))
 ```
 
 <!--- KNIT example-readme-01.kt -->
@@ -52,15 +52,14 @@ Either.Left(ExactError(message=Cannot be blank.))
 
 You can also define `Exact` by using Kotlin delegation.
 <!--- INCLUDE
-import arrow.core.raise.ensure
 import arrow.exact.Exact
-import arrow.exact.ExactError
+import arrow.exact.ensure
 -->
 ```kotlin
 @JvmInline
 value class NotBlankString private constructor(val value: String) {
    companion object : Exact<String, NotBlankString> by Exact({
-     ensure(it.isNotBlank()) { ExactError("Cannot be blank.") }
+     ensure(it.isNotBlank())
      NotBlankString(it)
    })
 }
@@ -68,20 +67,20 @@ value class NotBlankString private constructor(val value: String) {
 <!--- KNIT example-readme-02.kt -->
 
 You can define a second type `NotBlankTrimmedString` that is a `NotBlankString` that is also
-trimmed. Since the `ensure` allows us to compose `Exact` instances, we can easily
+trimmed. `ensureExact` allows us to compose `Exact` instances and easily
 reuse the `NotBlankString` type.
 <!--- INCLUDE
 import arrow.core.raise.Raise
-import arrow.core.raise.ensure
 import arrow.exact.Exact
 import arrow.exact.ExactError
 import arrow.exact.ensure
+import arrow.exact.ensureExact
 
 @JvmInline
 value class NotBlankString private constructor(val value: String) {
   companion object : Exact<String, NotBlankString> {
     override fun Raise<ExactError>.spec(raw: String): NotBlankString {
-      ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
+      ensure(raw.isNotBlank())
       return NotBlankString(raw)
     }
   }
@@ -93,7 +92,7 @@ value class NotBlankString private constructor(val value: String) {
 value class NotBlankTrimmedString private constructor(val value: String) { 
   companion object : Exact<String, NotBlankTrimmedString> { 
     override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString { 
-      ensure(raw, NotBlankString)
+      ensureExact(raw, NotBlankString)
       return NotBlankTrimmedString(raw.trim())
     }
   }

--- a/guide/src/commonMain/kotlin/examples/example-exact-01.kt
+++ b/guide/src/commonMain/kotlin/examples/example-exact-01.kt
@@ -2,15 +2,15 @@
 package arrow.exact.knit.example.exampleExact01
 
 import arrow.core.raise.Raise
-import arrow.core.raise.ensure
 import arrow.exact.Exact
 import arrow.exact.ExactError
+import arrow.exact.ensure
 
 @JvmInline
 value class NotBlankString private constructor(val value: String) {
   companion object : Exact<String, NotBlankString> {
     override fun Raise<ExactError>.spec(raw: String): NotBlankString {
-      ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
+      ensure(raw.isNotBlank())
       return NotBlankString(raw)
     }
   }

--- a/guide/src/commonMain/kotlin/examples/example-exact-02.kt
+++ b/guide/src/commonMain/kotlin/examples/example-exact-02.kt
@@ -1,14 +1,13 @@
 // This file was automatically generated from Exact.kt by Knit tool. Do not edit.
 package arrow.exact.knit.example.exampleExact02
 
-import arrow.core.raise.ensure
 import arrow.exact.Exact
-import arrow.exact.ExactError
+import arrow.exact.ensure
 
 @JvmInline
 value class NotBlankString private constructor(val value: String) {
   companion object : Exact<String, NotBlankString> by Exact({
-    ensure(it.isNotBlank()) { ExactError("Cannot be blank.") }
+    ensure(it.isNotBlank())
     NotBlankString(it)
   })
 }

--- a/guide/src/commonMain/kotlin/examples/example-exact-03.kt
+++ b/guide/src/commonMain/kotlin/examples/example-exact-03.kt
@@ -2,15 +2,15 @@
 package arrow.exact.knit.example.exampleExact03
 
 import arrow.core.raise.Raise
-import arrow.core.raise.ensure
 import arrow.exact.Exact
 import arrow.exact.ExactError
 import arrow.exact.ensure
+import arrow.exact.ensureExact
 
 class NotBlankString private constructor(val value: String) {
   companion object : Exact<String, NotBlankString> {
     override fun Raise<ExactError>.spec(raw: String): NotBlankString {
-      ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
+      ensure(raw.isNotBlank())
       return NotBlankString(raw)
     }
   }
@@ -20,7 +20,7 @@ class NotBlankString private constructor(val value: String) {
 value class NotBlankTrimmedString private constructor(val value: String) {
   companion object : Exact<String, NotBlankTrimmedString> {
     override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString {
-      ensure(raw, NotBlankString)
+      ensureExact(raw, NotBlankString)
       return NotBlankTrimmedString(raw.trim())
     }
   }

--- a/guide/src/commonMain/kotlin/examples/example-exact-04.kt
+++ b/guide/src/commonMain/kotlin/examples/example-exact-04.kt
@@ -7,12 +7,13 @@ import arrow.exact.Exact
 import arrow.exact.ExactEither
 import arrow.exact.ExactError
 import arrow.exact.ensure
+import arrow.exact.ensureExact
 
 @JvmInline
 value class NotBlankTrimmedString private constructor(val value: String) {
   companion object : Exact<String, NotBlankTrimmedString> {
     override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString {
-      ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
+      ensure(raw.isNotBlank())
       return NotBlankTrimmedString(raw.trim())
     }
   }
@@ -28,7 +29,7 @@ value class Username private constructor(val value: String) {
   companion object : ExactEither<UsernameError, String, Username> {
     override fun Raise<UsernameError>.spec(raw: String): Username {
       val username =
-        ensure(raw, NotBlankTrimmedString) {
+        ensureExact(raw, NotBlankTrimmedString) {
           UsernameError.Invalid
         }.value
       ensure(username.length < 100) { UsernameError.Invalid }

--- a/guide/src/commonMain/kotlin/examples/example-readme-01.kt
+++ b/guide/src/commonMain/kotlin/examples/example-readme-01.kt
@@ -2,15 +2,15 @@
 package arrow.exact.knit.example.exampleReadme01
 
 import arrow.core.raise.Raise
-import arrow.core.raise.ensure
 import arrow.exact.Exact
 import arrow.exact.ExactError
+import arrow.exact.ensure
 
 @JvmInline
 value class NotBlankString private constructor(val value: String) { 
   companion object : Exact<String, NotBlankString> {
     override fun Raise<ExactError>.spec(raw: String): NotBlankString { 
-      ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
+      ensure(raw.isNotBlank())
       return NotBlankString(raw)
     }
   }

--- a/guide/src/commonMain/kotlin/examples/example-readme-02.kt
+++ b/guide/src/commonMain/kotlin/examples/example-readme-02.kt
@@ -1,14 +1,13 @@
 // This file was automatically generated from README.md by Knit tool. Do not edit.
 package arrow.exact.knit.example.exampleReadme02
 
-import arrow.core.raise.ensure
 import arrow.exact.Exact
-import arrow.exact.ExactError
+import arrow.exact.ensure
 
 @JvmInline
 value class NotBlankString private constructor(val value: String) {
    companion object : Exact<String, NotBlankString> by Exact({
-     ensure(it.isNotBlank()) { ExactError("Cannot be blank.") }
+     ensure(it.isNotBlank())
      NotBlankString(it)
    })
 }

--- a/guide/src/commonMain/kotlin/examples/example-readme-03.kt
+++ b/guide/src/commonMain/kotlin/examples/example-readme-03.kt
@@ -2,16 +2,16 @@
 package arrow.exact.knit.example.exampleReadme03
 
 import arrow.core.raise.Raise
-import arrow.core.raise.ensure
 import arrow.exact.Exact
 import arrow.exact.ExactError
 import arrow.exact.ensure
+import arrow.exact.ensureExact
 
 @JvmInline
 value class NotBlankString private constructor(val value: String) {
   companion object : Exact<String, NotBlankString> {
     override fun Raise<ExactError>.spec(raw: String): NotBlankString {
-      ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
+      ensure(raw.isNotBlank())
       return NotBlankString(raw)
     }
   }
@@ -21,7 +21,7 @@ value class NotBlankString private constructor(val value: String) {
 value class NotBlankTrimmedString private constructor(val value: String) { 
   companion object : Exact<String, NotBlankTrimmedString> { 
     override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString { 
-      ensure(raw, NotBlankString)
+      ensureExact(raw, NotBlankString)
       return NotBlankTrimmedString(raw.trim())
     }
   }

--- a/guide/src/jvmTest/kotlin/examples/spec/ExactExampleSpec.kt
+++ b/guide/src/jvmTest/kotlin/examples/spec/ExactExampleSpec.kt
@@ -10,7 +10,7 @@ class ExactExampleSpec : StringSpec({
     captureOutput("ExampleExact01") { arrow.exact.knit.example.exampleExact01.example() }
       .verifyOutputLines(
         "Either.Right(NotBlankString(value=Hello))",
-        "Either.Left(ExactError(message=Cannot be blank.))"
+        "Either.Left(ExactError(message=Failed condition.))"
       )
   }
 

--- a/guide/src/jvmTest/kotlin/examples/spec/ReadMeSpec.kt
+++ b/guide/src/jvmTest/kotlin/examples/spec/ReadMeSpec.kt
@@ -10,7 +10,7 @@ class ReadMeSpec : StringSpec({
     captureOutput("ExampleReadme01") { arrow.exact.knit.example.exampleReadme01.example() }
       .verifyOutputLines(
         "Either.Right(NotBlankString(value=Hello))",
-        "Either.Left(ExactError(message=Cannot be blank.))"
+        "Either.Left(ExactError(message=Failed condition.))"
       )
   }
 

--- a/src/commonMain/kotlin/arrow/exact/Exact.kt
+++ b/src/commonMain/kotlin/arrow/exact/Exact.kt
@@ -14,15 +14,15 @@ import arrow.core.raise.ensure
  *
  * ```kotlin
  * import arrow.core.raise.Raise
- * import arrow.core.raise.ensure
  * import arrow.exact.Exact
  * import arrow.exact.ExactError
+ * import arrow.exact.ensure
  *
  * @JvmInline
  * value class NotBlankString private constructor(val value: String) {
  *   companion object : Exact<String, NotBlankString> {
  *     override fun Raise<ExactError>.spec(raw: String): NotBlankString {
- *       ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
+ *       ensure(raw.isNotBlank())
  *       return NotBlankString(raw)
  *     }
  *   }
@@ -45,22 +45,21 @@ import arrow.core.raise.ensure
  * The output of the above program is:
  * ```text
  * Either.Right(NotBlankString(value=Hello))
- * Either.Left(ExactError(message=Cannot be blank.))
+ * Either.Left(ExactError(message=Failed condition.))
  * ```
  * <!--- KNIT example-exact-01.kt -->
  * <!--- TEST -->
  *
  * You can also define [Exact] by using Kotlin delegation.
  * <!--- INCLUDE
- * import arrow.core.raise.ensure
  * import arrow.exact.Exact
- * import arrow.exact.ExactError
+ * import arrow.exact.ensure
  * -->
  * ```kotlin
  * @JvmInline
  * value class NotBlankString private constructor(val value: String) {
  *   companion object : Exact<String, NotBlankString> by Exact({
- *     ensure(it.isNotBlank()) { ExactError("Cannot be blank.") }
+ *     ensure(it.isNotBlank())
  *     NotBlankString(it)
  *   })
  * }
@@ -68,19 +67,19 @@ import arrow.core.raise.ensure
  * <!--- KNIT example-exact-02.kt -->
  *
  * You can define a second type `NotBlankTrimmedString` that is a `NotBlankString` that is also
- * trimmed. Since the [ensure] allows us to compose [Exact] instances, we can easily
+ * trimmed. [ensureExact] allows us to compose [Exact] instances and easily
  * reuse the `NotBlankString` type.
  * <!--- INCLUDE
  * import arrow.core.raise.Raise
- * import arrow.core.raise.ensure
  * import arrow.exact.Exact
  * import arrow.exact.ExactError
  * import arrow.exact.ensure
+ * import arrow.exact.ensureExact
  *
  * class NotBlankString private constructor(val value: String) {
  *   companion object : Exact<String, NotBlankString> {
  *     override fun Raise<ExactError>.spec(raw: String): NotBlankString {
- *       ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
+ *       ensure(raw.isNotBlank())
  *       return NotBlankString(raw)
  *     }
  *   }
@@ -91,7 +90,7 @@ import arrow.core.raise.ensure
  * value class NotBlankTrimmedString private constructor(val value: String) {
  *   companion object : Exact<String, NotBlankTrimmedString> {
  *     override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString {
- *       ensure(raw, NotBlankString)
+ *       ensureExact(raw, NotBlankString)
  *       return NotBlankTrimmedString(raw.trim())
  *     }
  *   }
@@ -118,12 +117,13 @@ public data class ExactError(val message: String)
  * import arrow.exact.ExactEither
  * import arrow.exact.ExactError
  * import arrow.exact.ensure
+ * import arrow.exact.ensureExact
  *
  * @JvmInline
  * value class NotBlankTrimmedString private constructor(val value: String) {
  *   companion object : Exact<String, NotBlankTrimmedString> {
  *     override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString {
- *       ensure(raw.isNotBlank()) { ExactError("Cannot be blank.") }
+ *       ensure(raw.isNotBlank())
  *       return NotBlankTrimmedString(raw.trim())
  *     }
  *   }
@@ -140,7 +140,7 @@ public data class ExactError(val message: String)
  *   companion object : ExactEither<UsernameError, String, Username> {
  *     override fun Raise<UsernameError>.spec(raw: String): Username {
  *       val username =
- *         ensure(raw, NotBlankTrimmedString) {
+ *         ensureExact(raw, NotBlankTrimmedString) {
  *           UsernameError.Invalid
  *         }.value
  *       ensure(username.length < 100) { UsernameError.Invalid }

--- a/src/commonMain/kotlin/arrow/exact/ExactDsl.kt
+++ b/src/commonMain/kotlin/arrow/exact/ExactDsl.kt
@@ -5,15 +5,21 @@ import arrow.core.raise.Raise
 import arrow.core.raise.RaiseDSL
 
 @RaiseDSL
-public inline fun <A, B, Error : Any> Raise<Error>.ensure(raw: A, exact: ExactEither<Error, A, B>): B {
-  return when (val result = exact.from(raw)) {
-    is Either.Left -> raise(result.value)
-    is Either.Right -> result.value
-  }
+public inline fun Raise<ExactError>.ensure(condition: Boolean) {
+  if (!condition) raise(ExactError("Failed condition."))
 }
 
 @RaiseDSL
-public inline fun <A, B, Error> Raise<Error>.ensure(raw: A, exact: Exact<A, B>, error: (ExactError) -> Error): B {
+public inline fun <A, B> Raise<ExactError>.ensureExact(raw: A, exact: Exact<A, B>): B = ensureExact(raw, exact as ExactEither<*, A, B>)
+
+@RaiseDSL
+public inline fun <A, B> Raise<ExactError>.ensureExact(raw: A, exact: ExactEither<*, A, B>): B = ensureExact(raw, exact) { ExactError("Failed to match Exact.") }
+
+@RaiseDSL
+public inline fun <A, B, Error : Any> Raise<Error>.ensureExact(raw: A, exact: Exact<A, B>, error: (ExactError) -> Error): B = ensureExact(raw, exact as ExactEither<ExactError, A, B>, error)
+
+@RaiseDSL
+public inline fun <A, B, Error : Any, E : Any> Raise<E>.ensureExact(raw: A, exact: ExactEither<Error, A, B>, error: (Error) -> E): B {
   return when (val result = exact.from(raw)) {
     is Either.Left -> raise(error(result.value))
     is Either.Right -> result.value


### PR DESCRIPTION
- Added `ensure(condition: Boolean)` for simple use-cases:

``` kotlin
companion object : Exact<String, NotBlankString> by Exact({
   ensure(it.isNotBlank()) // use default ExactError in case of error
   NotBlankString(it)
})
```

- Renamed to `ensureExact` because it conflicted with existing `ensure` from core. Exact is a functional interface and ide struggles to understand what function to use, `ensure(boolean, () -> Error)` or `ensure(boolean, Exact<Boolean, ...>)`:

``` kotlin
companion object : Exact<Int, ID> by Exact({
  ensure(it > 0) { ExactError("Some error") } // arrow.exact.ensure is used instead of arrow.core.raise.ensure
  ID(it)
})
```

- Added more `ensureExact` functions for composing `Exact`s
- Explicitly define all combination of `ensureExact` instead of using defaults for better experience in ide:

<img width="568" alt="image" src="https://github.com/arrow-kt/arrow-exact/assets/7880921/47d2058f-7b05-4d3c-a633-24d08fd93b6b">
