### PR TITLE
Exact typealias

### DIFF
--- a/src/commonMain/kotlin/arrow/exact/Exact.kt
+++ b/src/commonMain/kotlin/arrow/exact/Exact.kt
@@ -30,9 +30,9 @@ import arrow.core.raise.ensure
  * }
  * ```
  *
- * We can then easily create values of `NotBlankString` [from] a `String`, which returns us a
- * [Either] with the [ExactError] or the `NotBlankString`. We can also use [fromOrNull] to get a
- * nullable value, or [fromOrThrow] to throw an [ExactException].
+ * We can then easily create values of `NotBlankString` [ExactEither.from] a `String`, which returns us a
+ * [Either] with the [ExactError] or the `NotBlankString`. We can also use [ExactEither.fromOrNull] to get a
+ * nullable value, or [ExactEither.fromOrThrow] to throw an [ExactException].
  *
  * **note:** Make sure to define your constructor as `private` to prevent creating invalid values.
  *
@@ -102,15 +102,15 @@ import arrow.core.raise.ensure
  *
  * @see ExactEither if you need to return an [Either] with a custom error type.
  */
-public fun interface Exact<A, out R> : ExactEither<ExactError, A, R>
+public typealias Exact<A, R> = ExactEither<ExactError, A, R>
 
 // TODO: Should we just use `String` ???
 public data class ExactError(val message: String)
 
 /**
- * A more generic version of [Exact] that allows working over a custom error type rather than
- * [ExactError]. Since [Exact] is a specialization of [ExactEither], where [E] is fixed to
- * [ExactError], we can easily combine the two by mapping from [ExactError] to our custom [E] type.
+ * Input more generic version of [Exact] that allows working over a custom error type rather than
+ * [ExactError]. Since [Exact] is a specialization of [ExactEither], where [Error] is fixed to
+ * [ExactError], we can easily combine the two by mapping from [ExactError] to our custom [Error] type.
  *
  * <!--- INCLUDE
  * import arrow.core.raise.Raise
@@ -154,15 +154,15 @@ public data class ExactError(val message: String)
  * ```
  * <!--- KNIT example-exact-04.kt -->
  */
-public fun interface ExactEither<E : Any, A, out R> {
+public fun interface ExactEither<out Error : Any, in Input, out Output> {
 
-  public fun Raise<E>.spec(raw: A): R
+  public fun Raise<Error>.spec(raw: Input): Output
 
-  public fun from(value: A): Either<E, R> = either { spec(value) }
+  public fun from(value: Input): Either<Error, Output> = either { spec(value) }
 
-  public fun fromOrNull(value: A): R? = from(value).getOrNull()
+  public fun fromOrNull(value: Input): Output? = from(value).getOrNull()
 
-  public fun fromOrThrow(value: A): R =
+  public fun fromOrThrow(value: Input): Output =
     when (val result = from(value)) {
       is Either.Left -> throw ExactException(result.value)
       is Either.Right -> result.value

--- a/src/commonMain/kotlin/arrow/exact/ExactDsl.kt
+++ b/src/commonMain/kotlin/arrow/exact/ExactDsl.kt
@@ -5,20 +5,13 @@ import arrow.core.raise.Raise
 import arrow.core.raise.RaiseDSL
 
 @RaiseDSL
-public inline fun Raise<ExactError>.ensure(condition: Boolean) {
+public fun Raise<ExactError>.ensure(condition: Boolean) {
   if (!condition) raise(ExactError("Failed condition."))
 }
 
 @RaiseDSL
-public inline fun <A, B> Raise<ExactError>.ensure(raw: A, exact: Exact<A, B>): B = ensure(raw, exact as ExactEither<*, A, B>)
-
-@RaiseDSL
-public inline fun <A, B> Raise<ExactError>.ensure(raw: A, exact: ExactEither<*, A, B>): B =
+public fun <A, B> Raise<ExactError>.ensure(raw: A, exact: ExactEither<*, A, B>): B =
   ensure(raw, exact) { ExactError("Failed to match Exact.") }
-
-@RaiseDSL
-public inline fun <A, B, Error : Any> Raise<Error>.ensure(raw: A, exact: Exact<A, B>, error: (ExactError) -> Error): B =
-  ensure(raw, exact as ExactEither<ExactError, A, B>, error)
 
 @RaiseDSL
 public inline fun <A, B, Error : Any, E : Any> Raise<E>.ensure(raw: A, exact: ExactEither<Error, A, B>, error: (Error) -> E): B {


### PR DESCRIPTION
This PR replaces #26, making `Exact` a typealias simplifies the code and reduces the amount of `ensure` methods needed.

> @ustits attempt 2 🙈
> I think we've defined some duplicate APIs, but I am not entirely sure I am missing something. I am raising this PR instead of rolling back the commit. What do you think?
> All the existing code still compiles, but perhaps a corner case was not covered.