### PR TITLE
Change error handling for Exact

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ the Arrow's `Raise` DSL to `ensure` the value is not blank.
 ```kotlin
 import arrow.core.raise.Raise
 import arrow.exact.Exact
-import arrow.exact.ExactError
+import arrow.exact.ErrorMessage
 import arrow.exact.ensure
 import kotlin.jvm.JvmInline
 
 @JvmInline
 value class NotBlankString private constructor(val value: String) { 
   companion object : Exact<String, NotBlankString> {
-    override fun Raise<ExactError>.spec(raw: String): NotBlankString { 
+    override fun Raise<ErrorMessage>.spec(raw: String): NotBlankString { 
       ensure(raw.isNotBlank())
       return NotBlankString(raw)
     }
@@ -29,7 +29,7 @@ value class NotBlankString private constructor(val value: String) {
 ```
 
 We can then easily create values of `NotBlankString` `from` a `String`, which returns us a
-`Either` with the `ExactError` or the `NotBlankString`. We can also use `fromOrNull` to get a
+`Either` with the `ErrorMessage` or the `NotBlankString`. We can also use `fromOrNull` to get a
 nullable value, or `fromOrThrow` to throw an `ExactException`.
 
 **note:** Make sure to define your constructor as `private` to prevent creating invalid values.
@@ -45,7 +45,7 @@ The output of the above program is:
 
 ```text
 Either.Right(NotBlankString(value=Hello))
-Either.Left(ExactError(message=Failed condition.))
+Either.Left(ErrorMessage(message=Failed condition.))
 ```
 
 <!--- KNIT example-readme-01.kt -->
@@ -72,32 +72,26 @@ You can define a second type `NotBlankTrimmedString` that is a `NotBlankString` 
 trimmed. `ensureExact` allows us to compose `Exact` instances and easily
 reuse the `NotBlankString` type.
 <!--- INCLUDE
-import arrow.core.raise.Raise
 import arrow.exact.Exact
-import arrow.exact.ExactError
 import arrow.exact.ensure
 import kotlin.jvm.JvmInline
 
 @JvmInline
 value class NotBlankString private constructor(val value: String) {
-  companion object : Exact<String, NotBlankString> {
-    override fun Raise<ExactError>.spec(raw: String): NotBlankString {
-      ensure(raw.isNotBlank())
-      return NotBlankString(raw)
-    }
-  }
+  companion object : Exact<String, NotBlankString> by Exact({
+    ensure(it.isNotBlank())
+    NotBlankString(it)
+  })
 }
 -->
 
 ```kotlin
 @JvmInline
 value class NotBlankTrimmedString private constructor(val value: String) { 
-  companion object : Exact<String, NotBlankTrimmedString> { 
-    override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString { 
-      ensure(raw, NotBlankString)
-      return NotBlankTrimmedString(raw.trim())
-    }
-  }
+  companion object : Exact<String, NotBlankTrimmedString> by Exact({ 
+    ensure(it, NotBlankString)
+    NotBlankTrimmedString(it.trim())
+  })
 }
 ```
 

--- a/guide/src/commonMain/kotlin/examples/example-exact-01.kt
+++ b/guide/src/commonMain/kotlin/examples/example-exact-01.kt
@@ -3,14 +3,14 @@ package arrow.exact.knit.example.exampleExact01
 
 import arrow.core.raise.Raise
 import arrow.exact.Exact
-import arrow.exact.ExactError
+import arrow.exact.ErrorMessage
 import arrow.exact.ensure
 import kotlin.jvm.JvmInline
 
 @JvmInline
 value class NotBlankString private constructor(val value: String) {
   companion object : Exact<String, NotBlankString> {
-    override fun Raise<ExactError>.spec(raw: String): NotBlankString {
+    override fun Raise<ErrorMessage>.spec(raw: String): NotBlankString {
       ensure(raw.isNotBlank())
       return NotBlankString(raw)
     }

--- a/guide/src/commonMain/kotlin/examples/example-exact-03.kt
+++ b/guide/src/commonMain/kotlin/examples/example-exact-03.kt
@@ -1,27 +1,21 @@
 // This file was automatically generated from Exact.kt by Knit tool. Do not edit.
 package arrow.exact.knit.example.exampleExact03
 
-import arrow.core.raise.Raise
 import arrow.exact.Exact
-import arrow.exact.ExactError
 import arrow.exact.ensure
 import kotlin.jvm.JvmInline
 
 class NotBlankString private constructor(val value: String) {
-  companion object : Exact<String, NotBlankString> {
-    override fun Raise<ExactError>.spec(raw: String): NotBlankString {
-      ensure(raw.isNotBlank())
-      return NotBlankString(raw)
-    }
-  }
+  companion object : Exact<String, NotBlankString> by Exact({
+    ensure(it.isNotBlank())
+    NotBlankString(it)
+  })
 }
 
 @JvmInline
 value class NotBlankTrimmedString private constructor(val value: String) {
-  companion object : Exact<String, NotBlankTrimmedString> {
-    override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString {
-      ensure(raw, NotBlankString)
-      return NotBlankTrimmedString(raw.trim())
-    }
-  }
+  companion object : Exact<String, NotBlankTrimmedString> by Exact({
+    ensure(it, NotBlankString)
+    NotBlankTrimmedString(it.trim())
+  })
 }

--- a/guide/src/commonMain/kotlin/examples/example-exact-04.kt
+++ b/guide/src/commonMain/kotlin/examples/example-exact-04.kt
@@ -1,22 +1,18 @@
 // This file was automatically generated from Exact.kt by Knit tool. Do not edit.
 package arrow.exact.knit.example.exampleExact04
 
-import arrow.core.raise.Raise
 import arrow.core.raise.ensure
 import arrow.exact.Exact
 import arrow.exact.ExactEither
-import arrow.exact.ExactError
 import arrow.exact.ensure
 import kotlin.jvm.JvmInline
 
 @JvmInline
 value class NotBlankTrimmedString private constructor(val value: String) {
-  companion object : Exact<String, NotBlankTrimmedString> {
-    override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString {
-      ensure(raw.isNotBlank())
-      return NotBlankTrimmedString(raw.trim())
-    }
-  }
+  companion object : Exact<String, NotBlankTrimmedString> by Exact({
+    ensure(it.isNotBlank())
+    NotBlankTrimmedString(it.trim())
+  })
 }
 
 sealed interface UsernameError {
@@ -26,15 +22,13 @@ sealed interface UsernameError {
 
 @JvmInline
 value class Username private constructor(val value: String) {
-  companion object : ExactEither<UsernameError, String, Username> {
-    override fun Raise<UsernameError>.spec(raw: String): Username {
-      val username =
-        ensure(raw, NotBlankTrimmedString) {
-          UsernameError.Invalid
-        }.value
-      ensure(username.length < 100) { UsernameError.Invalid }
-      ensure(username !in listOf("offensive")) { UsernameError.Offensive(username) }
-      return Username(username)
-    }
-  }
+  companion object : ExactEither<UsernameError, String, Username> by ExactEither({
+    val username =
+      ensure(it, NotBlankTrimmedString) {
+        UsernameError.Invalid
+      }.value
+    ensure(username.length < 100) { UsernameError.Invalid }
+    ensure(username !in listOf("offensive")) { UsernameError.Offensive(username) }
+    Username(username)
+  })
 }

--- a/guide/src/commonMain/kotlin/examples/example-readme-01.kt
+++ b/guide/src/commonMain/kotlin/examples/example-readme-01.kt
@@ -3,14 +3,14 @@ package arrow.exact.knit.example.exampleReadme01
 
 import arrow.core.raise.Raise
 import arrow.exact.Exact
-import arrow.exact.ExactError
+import arrow.exact.ErrorMessage
 import arrow.exact.ensure
 import kotlin.jvm.JvmInline
 
 @JvmInline
 value class NotBlankString private constructor(val value: String) { 
   companion object : Exact<String, NotBlankString> {
-    override fun Raise<ExactError>.spec(raw: String): NotBlankString { 
+    override fun Raise<ErrorMessage>.spec(raw: String): NotBlankString { 
       ensure(raw.isNotBlank())
       return NotBlankString(raw)
     }

--- a/guide/src/commonMain/kotlin/examples/example-readme-03.kt
+++ b/guide/src/commonMain/kotlin/examples/example-readme-03.kt
@@ -1,28 +1,22 @@
 // This file was automatically generated from README.md by Knit tool. Do not edit.
 package arrow.exact.knit.example.exampleReadme03
 
-import arrow.core.raise.Raise
 import arrow.exact.Exact
-import arrow.exact.ExactError
 import arrow.exact.ensure
 import kotlin.jvm.JvmInline
 
 @JvmInline
 value class NotBlankString private constructor(val value: String) {
-  companion object : Exact<String, NotBlankString> {
-    override fun Raise<ExactError>.spec(raw: String): NotBlankString {
-      ensure(raw.isNotBlank())
-      return NotBlankString(raw)
-    }
-  }
+  companion object : Exact<String, NotBlankString> by Exact({
+    ensure(it.isNotBlank())
+    NotBlankString(it)
+  })
 }
 
 @JvmInline
 value class NotBlankTrimmedString private constructor(val value: String) { 
-  companion object : Exact<String, NotBlankTrimmedString> { 
-    override fun Raise<ExactError>.spec(raw: String): NotBlankTrimmedString { 
-      ensure(raw, NotBlankString)
-      return NotBlankTrimmedString(raw.trim())
-    }
-  }
+  companion object : Exact<String, NotBlankTrimmedString> by Exact({ 
+    ensure(it, NotBlankString)
+    NotBlankTrimmedString(it.trim())
+  })
 }

--- a/guide/src/jvmTest/kotlin/examples/spec/ExactExampleSpec.kt
+++ b/guide/src/jvmTest/kotlin/examples/spec/ExactExampleSpec.kt
@@ -10,7 +10,7 @@ class ExactExampleSpec : StringSpec({
     captureOutput("ExampleExact01") { arrow.exact.knit.example.exampleExact01.example() }
       .verifyOutputLines(
         "Either.Right(NotBlankString(value=Hello))",
-        "Either.Left(ExactError(message=Failed condition.))"
+        "Either.Left(ErrorMessage(message=Failed condition.))"
       )
   }
 

--- a/guide/src/jvmTest/kotlin/examples/spec/ReadMeSpec.kt
+++ b/guide/src/jvmTest/kotlin/examples/spec/ReadMeSpec.kt
@@ -10,7 +10,7 @@ class ReadMeSpec : StringSpec({
     captureOutput("ExampleReadme01") { arrow.exact.knit.example.exampleReadme01.example() }
       .verifyOutputLines(
         "Either.Right(NotBlankString(value=Hello))",
-        "Either.Left(ExactError(message=Failed condition.))"
+        "Either.Left(ErrorMessage(message=Failed condition.))"
       )
   }
 

--- a/src/commonMain/kotlin/arrow/exact/Exact.kt
+++ b/src/commonMain/kotlin/arrow/exact/Exact.kt
@@ -97,7 +97,7 @@ import kotlin.jvm.JvmInline
  *
  * @see ExactEither if you need to return an [Either] with a custom error type.
  */
-public typealias Exact<A, R> = ExactEither<ErrorMessage, A, R>
+public typealias Exact<Input, Output> = ExactEither<ErrorMessage, Input, Output>
 
 @JvmInline
 public value class ErrorMessage(public val message: String)

--- a/src/commonMain/kotlin/arrow/exact/ExactDsl.kt
+++ b/src/commonMain/kotlin/arrow/exact/ExactDsl.kt
@@ -5,13 +5,16 @@ import arrow.core.raise.Raise
 import arrow.core.raise.RaiseDSL
 
 @RaiseDSL
-public fun Raise<ExactError>.ensure(condition: Boolean) {
-  if (!condition) raise(ExactError("Failed condition."))
+public fun Raise<ErrorMessage>.ensure(condition: Boolean): Unit = ensure(condition) { "Failed condition." }
+
+@RaiseDSL
+public fun Raise<ErrorMessage>.ensure(condition: Boolean, lazyMessage: () -> String) {
+  if (!condition) raise(ErrorMessage(lazyMessage()))
 }
 
 @RaiseDSL
-public fun <A, B> Raise<ExactError>.ensure(raw: A, exact: ExactEither<*, A, B>): B =
-  ensure(raw, exact) { ExactError("Failed to match Exact.") }
+public fun <A, B> Raise<ErrorMessage>.ensure(raw: A, exact: ExactEither<*, A, B>): B =
+  ensure(raw, exact) { ErrorMessage("Failed to match Exact.") }
 
 @RaiseDSL
 public inline fun <A, B, Error : Any, E : Any> Raise<E>.ensure(raw: A, exact: ExactEither<Error, A, B>, error: (Error) -> E): B {


### PR DESCRIPTION
The change is a follow-up of this message https://github.com/arrow-kt/arrow-exact/pull/25#issuecomment-1596545009

- Added `ensure(condition: Boolean, lazyMessage: () -> String)` function
- Renamed `ExactError` to `ErrorMessage`
- Replaced most of the examples in doc to `by Exact({})` instead of inheritance