### PR TITLE
SuspendExact

### DIFF
--- a/src/commonMain/kotlin/arrow/exact/SuspendExact.kt
+++ b/src/commonMain/kotlin/arrow/exact/SuspendExact.kt
@@ -1,0 +1,25 @@
+package arrow.exact
+
+import arrow.core.Either
+import arrow.core.raise.Raise
+import arrow.core.raise.either
+
+//TODO: add documentation
+//TODO: fix coding style (see #33)
+
+public typealias SuspendExact<A, R> = SuspendExactEither<ExactError, A, R>
+
+public interface SuspendExactEither<out Error: Any, in Input, out Output> {
+
+	public suspend fun Raise<Error>.spec(raw: Input): Output
+
+	public suspend fun from(value: Input): Either<Error, Output> = either { spec(value) }
+
+	public suspend fun fromOrNull(value: Input): Output? = from(value).getOrNull()
+
+	public suspend fun fromOrThrow(value: Input): Output =
+		when (val result = from(value)) {
+			is Either.Left -> throw ExactException(result.value)
+			is Either.Right -> result.value
+		}
+}


### PR DESCRIPTION
Prototype for SuspendExact, which aims to allow validation using external services (e.g. verify that an ID does in fact exist).

Closes #33 